### PR TITLE
feat(exec): standalone-agent messaging substrate for chat-with-agent

### DIFF
--- a/internal/exec/agent_handle.go
+++ b/internal/exec/agent_handle.go
@@ -124,6 +124,74 @@ type AgentHandle struct {
 	// which bucket to purge after Done closes. Empty string is a
 	// valid bucket (single-session deployments).
 	sessionID string
+
+	// msg is the per-call messaging substrate (router, mailbox, wake
+	// channel, derived primary step ID, run ID). RunAgentAsync builds
+	// it before the agent goroutine starts and shares the same
+	// instance with the inner runAgent call, so SendMessage can
+	// address the running agent's mailbox. nil only on handles built
+	// via NewAgentHandle (test fixtures); SendMessage guards on it.
+	msg *agentMessaging
+}
+
+// RunID returns the zenflow run ID of the agent behind this handle.
+// Pair with PrimaryStepID to load the agent's transcript from a
+// TranscriptStore (resurrection). Empty when the handle was built via
+// NewAgentHandle without a messaging substrate.
+func (h *AgentHandle) RunID() string {
+	if h == nil || h.msg == nil {
+		return ""
+	}
+	return h.msg.runID
+}
+
+// PrimaryStepID returns the step ID the standalone agent's transcript
+// and mailbox are keyed by. Pair with RunID for TranscriptStore.Load.
+func (h *AgentHandle) PrimaryStepID() string {
+	if h == nil || h.msg == nil {
+		return ""
+	}
+	return h.msg.primaryStepID
+}
+
+// SendMessage delivers a user message into a still-running agent's
+// mailbox and signals its wake channel, so the agent picks the
+// message up at its next turn boundary. The return string mirrors the
+// router contract: "queued: <stepID>" on success, "dropped: <reason>"
+// when the agent has already finished (its inbox is closed) - the
+// consumer reads a drop as "agent done, resurrect instead". Returns a
+// non-nil error only on misuse (a handle with no messaging substrate).
+func (h *AgentHandle) SendMessage(text string) (string, error) {
+	if h == nil || h.msg == nil || h.msg.router == nil {
+		return "", errors.New("zenflow: agent handle has no messaging substrate")
+	}
+	// Fast-path: the agent already finished. Its inbox is closed; a
+	// Send would drop anyway, but checking finished first gives the
+	// caller a stable signal instead of a router-internal reason.
+	select {
+	case <-h.finished:
+		return "dropped: " + DropReasonStrings()[DropReasonTargetTerminal], nil
+	default:
+	}
+	m := RouterMessage{
+		From:      "user",
+		To:        h.msg.primaryStepID,
+		Content:   text,
+		Type:      RouterMessageInfo,
+		Timestamp: time.Now(),
+	}
+	if err := h.msg.router.Send(h.msg.primaryStepID, m); err != nil {
+		// *DropError.Error() already starts with "dropped: " - pass
+		// through verbatim rather than double-prefixing.
+		return err.Error(), nil
+	}
+	// Non-blocking wake: a buffered (cap-1) signal already pending is
+	// sufficient - the runner drains the whole mailbox on each wake.
+	select {
+	case h.msg.wake <- struct{}{}:
+	default:
+	}
+	return "queued: " + h.msg.primaryStepID, nil
 }
 
 // NewAgentHandle constructs an AgentHandle with both internal
@@ -248,7 +316,23 @@ func newAgentHandleID() (string, error) {
 // ProgressSink, SubagentToolSet, SessionID, etc.) flows through to
 // the runner - no silent field dropping.
 var runAgentAsyncRunner = func(o *Orchestrator, ctx context.Context, cfg AgentConfig) (*AgentResult, error) {
-	return o.RunAgent(ctx, cfg)
+	return o.runAgent(ctx, cfg, msFromContext(ctx))
+}
+
+// msCtxKey keys the per-call agentMessaging substrate stored on the
+// RunAgentAsync context. RunAgentAsync builds the substrate, attaches
+// it to the AgentHandle (for SendMessage) AND threads it through the
+// context so the default runAgentAsyncRunner can hand the same
+// instance to runAgent - without changing the public 3-arg test seam
+// signature. Tests that override runAgentAsyncRunner return synthetic
+// results and never call runAgent, so they ignore the key.
+type msCtxKey struct{}
+
+// msFromContext extracts the agentMessaging substrate threaded onto a
+// RunAgentAsync context, or nil for a synchronous RunAgent call.
+func msFromContext(ctx context.Context) *agentMessaging {
+	ms, _ := ctx.Value(msCtxKey{}).(*agentMessaging)
+	return ms
 }
 
 // SetRunAgentAsyncRunnerForTest swaps runAgentAsyncRunner so tests
@@ -292,13 +376,31 @@ func (o *Orchestrator) RunAgentAsync(ctx context.Context, cfg AgentConfig) (*Age
 	if err != nil {
 		return nil, err
 	}
+	// Build the messaging substrate so the AgentHandle can address the
+	// running agent's mailbox via SendMessage. The same instance is
+	// threaded onto runCtx so the inner runAgent shares it instead of
+	// building its own.
+	//
+	// Unlike RunFlow / synchronous RunAgent, RunAgentAsync ALWAYS
+	// generates a fresh run ID and never honours o.runID: a single
+	// orchestrator spawns many concurrent async agents (the consumer's
+	// BG-agent + task-subagent fan-out), and each needs its own run ID
+	// so their transcripts and mailboxes do not collide. The handle ID
+	// is the caller-facing identity; the run ID is internal.
+	runID, err := GenerateRunID()
+	if err != nil {
+		return nil, err
+	}
+	ms := newAgentMessaging(runID)
 	runCtx, cancel := context.WithCancel(ctx)
+	runCtx = context.WithValue(runCtx, msCtxKey{}, ms)
 	h := &AgentHandle{
 		ID:        id,
 		done:      make(chan AgentResult, 1),
 		finished:  make(chan struct{}),
 		cancel:    cancel,
 		sessionID: cfg.SessionID,
+		msg:       ms,
 	}
 
 	// Register the handle under its sessionID so ListAgentHandles

--- a/internal/exec/agent_messaging.go
+++ b/internal/exec/agent_messaging.go
@@ -1,0 +1,46 @@
+package exec
+
+// agent_messaging.go - the per-call messaging substrate for a
+// standalone agent run (AUV2 PR4 "chat with a running agent").
+//
+// A workflow step agent reaches its mailbox through the executor's
+// DeliveryEngine. A standalone agent spawned via RunAgent /
+// RunAgentAsync has no executor, so the substrate is built per-call:
+// one MessageRouter, one in-memory MailboxStore, one wake channel and
+// the derived primary step ID. RunAgentAsync builds it up front and
+// attaches it to the AgentHandle so AgentHandle.SendMessage can
+// address the running agent's mailbox directly.
+
+// agentMessaging bundles the router, mailbox, wake channel, primary
+// step ID and run ID for one standalone agent invocation. The same
+// instance is shared between the AgentHandle (for SendMessage) and the
+// inner runAgent call (which wires it into the AgentRunner).
+type agentMessaging struct {
+	runID         string
+	router        *MessageRouter
+	mailbox       MailboxStore
+	wake          chan struct{}
+	primaryStepID string
+}
+
+// newAgentMessaging builds a fresh messaging substrate for runID. The
+// router gets an in-memory mailbox; the primary step ID is registered
+// as both a step and an inbox so router.Send addressed to it is
+// accepted. The wake channel is cap-1 buffered, matching the runner's
+// mailbox-mode contract (a pending signal coalesces - the runner
+// drains the whole mailbox per wake).
+func newAgentMessaging(runID string) *agentMessaging {
+	r := NewMessageRouter()
+	mb := NewInMemoryMailboxStore()
+	r.SetMailbox(mb)
+	stepID := agentPrimaryStepID(runID)
+	r.RegisterStep(stepID)
+	r.RegisterInbox(stepID)
+	return &agentMessaging{
+		runID:         runID,
+		router:        r,
+		mailbox:       mb,
+		wake:          make(chan struct{}, 1),
+		primaryStepID: stepID,
+	}
+}

--- a/internal/exec/agent_messaging_test.go
+++ b/internal/exec/agent_messaging_test.go
@@ -1,0 +1,269 @@
+package exec
+
+// agent_messaging_test.go - AUV2 PR4 zenflow surface: AgentConfig
+// InitialMessages plumbing, standalone-agent transcript persistence,
+// and AgentHandle.SendMessage / RunID / PrimaryStepID.
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/zendev-sh/goai/provider"
+
+	"github.com/zendev-sh/zenflow/internal/resume"
+)
+
+func userMsg(text string) provider.Message {
+	return provider.Message{
+		Role:    provider.RoleUser,
+		Content: []provider.Part{{Type: provider.PartText, Text: text}},
+	}
+}
+
+func msgText(m provider.Message) string {
+	var b strings.Builder
+	for _, p := range m.Content {
+		if p.Type == provider.PartText {
+			b.WriteString(p.Text)
+		}
+	}
+	return b.String()
+}
+
+// TestNewAgentMessaging verifies the per-call substrate is fully wired:
+// router with an installed mailbox, a cap-1 wake channel, and the
+// primary step ID derived from the run ID and registered as an inbox.
+func TestNewAgentMessaging(t *testing.T) {
+	ms := newAgentMessaging("run-xyz")
+	if ms.runID != "run-xyz" {
+		t.Fatalf("runID = %q, want run-xyz", ms.runID)
+	}
+	if ms.primaryStepID != agentPrimaryStepID("run-xyz") {
+		t.Fatalf("primaryStepID = %q, want %q", ms.primaryStepID, agentPrimaryStepID("run-xyz"))
+	}
+	if ms.router == nil || ms.router.Mailbox() == nil {
+		t.Fatal("router/mailbox not wired")
+	}
+	if ms.mailbox == nil {
+		t.Fatal("mailbox nil")
+	}
+	if cap(ms.wake) != 1 {
+		t.Fatalf("wake cap = %d, want 1", cap(ms.wake))
+	}
+	// The inbox must accept a Send addressed to the primary step.
+	if err := ms.router.Send(ms.primaryStepID, RouterMessage{
+		To: ms.primaryStepID, Content: "ping", Type: RouterMessageInfo,
+	}); err != nil {
+		t.Fatalf("Send to registered inbox: %v", err)
+	}
+}
+
+// TestRunAgent_InitialMessages_Prepended asserts AgentConfig.InitialMessages
+// flows through RunAgent into the runner: the saved transcript lands
+// before the new user prompt in the very first LLM call.
+func TestRunAgent_InitialMessages_Prepended(t *testing.T) {
+	model := &mockModel{responses: []*provider.GenerateResult{textResult("ok", 1, 1)}}
+	o := New(WithModel(model), WithDefaultModel("gpt-4o"))
+
+	_, err := o.RunAgent(t.Context(), AgentConfig{
+		Prompt:          "NEWPROMPT",
+		InitialMessages: []provider.Message{userMsg("PRIORONE"), userMsg("PRIORTWO")},
+	})
+	if err != nil {
+		t.Fatalf("RunAgent: %v", err)
+	}
+	calls := model.getCalls()
+	if len(calls) == 0 {
+		t.Fatal("model never called")
+	}
+	msgs := calls[0].Messages
+	if len(msgs) < 3 {
+		t.Fatalf("first call has %d messages, want >=3 (2 prior + new)", len(msgs))
+	}
+	if got := msgText(msgs[0]); got != "PRIORONE" {
+		t.Errorf("msg[0] = %q, want PRIORONE", got)
+	}
+	if got := msgText(msgs[1]); got != "PRIORTWO" {
+		t.Errorf("msg[1] = %q, want PRIORTWO", got)
+	}
+	if got := msgText(msgs[2]); !strings.Contains(got, "NEWPROMPT") {
+		t.Errorf("msg[2] = %q, want it to contain NEWPROMPT", got)
+	}
+}
+
+// TestRunAgent_NoInitialMessages_ColdStart asserts the cold-start path
+// is unchanged: with no InitialMessages the first call sees only the
+// new user prompt.
+func TestRunAgent_NoInitialMessages_ColdStart(t *testing.T) {
+	model := &mockModel{responses: []*provider.GenerateResult{textResult("ok", 1, 1)}}
+	o := New(WithModel(model), WithDefaultModel("gpt-4o"))
+
+	if _, err := o.RunAgent(t.Context(), AgentConfig{Prompt: "HELLO"}); err != nil {
+		t.Fatalf("RunAgent: %v", err)
+	}
+	msgs := model.getCalls()[0].Messages
+	if len(msgs) != 1 {
+		t.Fatalf("cold start first call has %d messages, want 1", len(msgs))
+	}
+	if got := msgText(msgs[0]); !strings.Contains(got, "HELLO") {
+		t.Errorf("msg[0] = %q, want it to contain HELLO", got)
+	}
+}
+
+// TestRunAgent_TranscriptPersisted asserts a standalone RunAgent
+// persists its conversation to the orchestrator's TranscriptStore,
+// keyed by (runID, primaryStepID), so the agent can later be
+// resurrected from the saved transcript.
+func TestRunAgent_TranscriptPersisted(t *testing.T) {
+	model := &mockModel{responses: []*provider.GenerateResult{textResult("the-answer", 1, 1)}}
+	store := resume.NewInMemoryTranscriptStore()
+	o := New(
+		WithModel(model),
+		WithDefaultModel("gpt-4o"),
+		WithRunID("run-fixed-1"),
+		WithTranscriptStore(func() resume.TranscriptStore { return store }),
+	)
+	if _, err := o.RunAgent(t.Context(), AgentConfig{Prompt: "the-question"}); err != nil {
+		t.Fatalf("RunAgent: %v", err)
+	}
+	tr, err := store.Load("run-fixed-1", agentPrimaryStepID("run-fixed-1"))
+	if err != nil {
+		t.Fatalf("transcript not persisted: Load: %v", err)
+	}
+	if len(tr.Messages) == 0 {
+		t.Fatal("persisted transcript has no messages")
+	}
+	if got := msgText(tr.Messages[0]); !strings.Contains(got, "the-question") {
+		t.Errorf("transcript msg[0] = %q, want it to contain the-question", got)
+	}
+}
+
+// TestRunAgentAsync_HandleExposesRunIDAndStepID asserts the AgentHandle
+// surfaces the run ID and primary step ID so a consumer can load the
+// agent's transcript for resurrection.
+func TestRunAgentAsync_HandleExposesRunIDAndStepID(t *testing.T) {
+	model := &mockModel{responses: []*provider.GenerateResult{textResult("ok", 1, 1)}}
+	o := New(WithModel(model), WithDefaultModel("gpt-4o"))
+	h, err := o.RunAgentAsync(t.Context(), AgentConfig{Prompt: "go"})
+	if err != nil {
+		t.Fatalf("RunAgentAsync: %v", err)
+	}
+	if h.RunID() == "" {
+		t.Error("RunID() empty")
+	}
+	if h.PrimaryStepID() != agentPrimaryStepID(h.RunID()) {
+		t.Errorf("PrimaryStepID() = %q, want %q", h.PrimaryStepID(), agentPrimaryStepID(h.RunID()))
+	}
+	<-h.Done()
+}
+
+// TestRunAgentAsync_DistinctRunIDsPerAgent asserts each async agent
+// gets its own run ID even on a shared orchestrator (and even when
+// that orchestrator was built with WithRunID), so concurrent agents'
+// transcripts and mailboxes never collide.
+func TestRunAgentAsync_DistinctRunIDsPerAgent(t *testing.T) {
+	model := &mockModel{responses: []*provider.GenerateResult{
+		textResult("a", 1, 1), textResult("b", 1, 1),
+	}}
+	o := New(WithModel(model), WithDefaultModel("gpt-4o"), WithRunID("pinned-run"))
+	h1, err := o.RunAgentAsync(t.Context(), AgentConfig{Prompt: "1"})
+	if err != nil {
+		t.Fatalf("RunAgentAsync 1: %v", err)
+	}
+	h2, err := o.RunAgentAsync(t.Context(), AgentConfig{Prompt: "2"})
+	if err != nil {
+		t.Fatalf("RunAgentAsync 2: %v", err)
+	}
+	if h1.RunID() == h2.RunID() {
+		t.Fatalf("two async agents share run ID %q - transcripts/mailboxes would collide", h1.RunID())
+	}
+	if h1.RunID() == "pinned-run" || h2.RunID() == "pinned-run" {
+		t.Error("RunAgentAsync honoured o.runID - must always generate a fresh one")
+	}
+	<-h1.Done()
+	<-h2.Done()
+}
+
+// TestAgentHandle_SendMessage_QueuesIntoMailbox asserts SendMessage on
+// a running agent appends the message to the agent's mailbox and
+// signals its wake channel.
+func TestAgentHandle_SendMessage_QueuesIntoMailbox(t *testing.T) {
+	// blockingModel parks in DoGenerate until ctx cancel, keeping the
+	// agent "running" for the duration of the test.
+	model := &blockingModel{}
+	o := New(WithModel(model), WithDefaultModel("gpt-4o"))
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	h, err := o.RunAgentAsync(ctx, AgentConfig{Prompt: "work"})
+	if err != nil {
+		t.Fatalf("RunAgentAsync: %v", err)
+	}
+	res, err := h.SendMessage("user-followup")
+	if err != nil {
+		t.Fatalf("SendMessage: %v", err)
+	}
+	if res != "queued: "+h.PrimaryStepID() {
+		t.Errorf("SendMessage result = %q, want queued: %s", res, h.PrimaryStepID())
+	}
+	unread := h.msg.mailbox.Unread(h.msg.primaryStepID)
+	if len(unread) != 1 {
+		t.Fatalf("mailbox has %d unread, want 1", len(unread))
+	}
+	if unread[0].Content != "user-followup" {
+		t.Errorf("queued message = %q, want user-followup", unread[0].Content)
+	}
+	select {
+	case <-h.msg.wake:
+		// wake signalled - good
+	default:
+		t.Error("wake channel was not signalled")
+	}
+}
+
+// TestAgentHandle_SendMessage_AfterFinish_Drops asserts SendMessage to
+// an already-finished agent returns a target-terminal drop so the
+// consumer routes to the resurrection path instead.
+func TestAgentHandle_SendMessage_AfterFinish_Drops(t *testing.T) {
+	model := &mockModel{responses: []*provider.GenerateResult{textResult("done", 1, 1)}}
+	o := New(WithModel(model), WithDefaultModel("gpt-4o"))
+	h, err := o.RunAgentAsync(t.Context(), AgentConfig{Prompt: "quick"})
+	if err != nil {
+		t.Fatalf("RunAgentAsync: %v", err)
+	}
+	<-h.Done()
+	res, err := h.SendMessage("too-late")
+	if err != nil {
+		t.Fatalf("SendMessage: %v", err)
+	}
+	if !strings.HasPrefix(res, "dropped:") {
+		t.Errorf("SendMessage to finished agent = %q, want a dropped: result", res)
+	}
+}
+
+// TestAgentHandle_SendMessage_NoSubstrate asserts a handle with no
+// messaging substrate (built via NewAgentHandle in test fixtures)
+// returns an error rather than panicking.
+func TestAgentHandle_SendMessage_NoSubstrate(t *testing.T) {
+	h, err := NewAgentHandle("agent-fixture")
+	if err != nil {
+		t.Fatalf("NewAgentHandle: %v", err)
+	}
+	if _, err := h.SendMessage("x"); err == nil {
+		t.Error("SendMessage on substrate-less handle returned nil error")
+	}
+	if h.RunID() != "" || h.PrimaryStepID() != "" {
+		t.Error("substrate-less handle should report empty RunID/PrimaryStepID")
+	}
+}
+
+// TestAgentHandle_SendMessage_NilReceiver guards the nil-handle path.
+func TestAgentHandle_SendMessage_NilReceiver(t *testing.T) {
+	var h *AgentHandle
+	if _, err := h.SendMessage("x"); err == nil {
+		t.Error("SendMessage on nil handle returned nil error")
+	}
+	if h.RunID() != "" || h.PrimaryStepID() != "" {
+		t.Error("nil handle should report empty RunID/PrimaryStepID")
+	}
+}

--- a/internal/exec/agent_runner.go
+++ b/internal/exec/agent_runner.go
@@ -116,8 +116,20 @@ type AgentRunner struct {
 	// StopCausePredicate.
 	// - AgentRunner then drains mailbox.Unread, MarkReads them, and
 	// re-enters goai.GenerateText with the appended messages.
-	// When mailbox+Wake are nil, the runner skips messaging entirely (the
-	// agent has no inter-agent inbox, e.g. the standalone RunAgent path).
+	//
+	// Standalone-agent contract (RunAgent / RunAgentAsync, AUV2 PR4
+	// "chat with a running agent"): the standalone path wires a
+	// per-call mailbox + Wake too, but with NO DeliveryEngine ticking.
+	// Instead AgentHandle.SendMessage is the producer: it appends the
+	// user message to the mailbox and signals Wake directly. The
+	// runner picks the message up at its next turn boundary exactly as
+	// above. Delivery is therefore only possible WHILE the agent is
+	// still running: once the runner reaches a natural idle exit it
+	// returns and RunAgent closes the inbox, so a later SendMessage
+	// drops with target-terminal. The consumer reads that drop as
+	// "agent finished" and resurrects it from its saved transcript
+	// instead. When mailbox+Wake are nil the runner skips messaging
+	// entirely (the agent has no inbox at all).
 	mailbox MailboxStore
 	wake    chan struct{}
 

--- a/internal/exec/zenflow.go
+++ b/internal/exec/zenflow.go
@@ -267,6 +267,18 @@ func (o *Orchestrator) HasLLM() bool {
 // fall back to the Orchestrator defaults (registered via WithModel /
 // WithTools / WithProgress / WithMaxTurns) when unset. Stable.
 func (o *Orchestrator) RunAgent(ctx context.Context, cfg AgentConfig) (*AgentResult, error) {
+	return o.runAgent(ctx, cfg, nil)
+}
+
+// runAgent is the shared implementation behind RunAgent and
+// RunAgentAsync. When ms is nil (synchronous RunAgent) the messaging
+// substrate - per-call MessageRouter, MailboxStore, wake channel and
+// derived primary step ID - is built fresh here. When ms is non-nil
+// (RunAgentAsync) it was pre-built by the caller and attached to the
+// AgentHandle so consumers can address the running agent's mailbox
+// via AgentHandle.SendMessage. The runID is taken from ms when
+// provided so the handle, the transcript slot and the run all agree.
+func (o *Orchestrator) runAgent(ctx context.Context, cfg AgentConfig, ms *agentMessaging) (*AgentResult, error) {
 	// Symmetric with RunAgentAsync: once Close has been called, the
 	// orchestrator's background goroutines are cancelled and its
 	// handle registry has been drained; a new RunAgent would be
@@ -280,7 +292,12 @@ func (o *Orchestrator) RunAgent(ctx context.Context, cfg AgentConfig) (*AgentRes
 	}
 
 	// Generate run ID for tracing, or use caller-supplied ID when set.
+	// When the caller pre-built the messaging substrate (RunAgentAsync)
+	// its runID is authoritative so the handle and run never diverge.
 	runID := o.runID
+	if ms != nil {
+		runID = ms.runID
+	}
 	if runID == "" {
 		var err error
 		runID, err = GenerateRunID()
@@ -310,8 +327,12 @@ func (o *Orchestrator) RunAgent(ctx context.Context, cfg AgentConfig) (*AgentRes
 	// agent-tool-spawned children. This unlocks inter-agent messaging
 	// on the RunAgent path. The mailbox is per-call - successive
 	// RunAgent invocations get distinct mailbox instances so inbox
-	// state cannot leak between calls.
-	router := NewMessageRouter()
+	// state cannot leak between calls. RunAgentAsync supplies the
+	// substrate pre-built so the AgentHandle shares the same router.
+	if ms == nil {
+		ms = newAgentMessaging(runID)
+	}
+	router := ms.router
 	if o.routerObserver != nil {
 		// Observer panics MUST NOT crash the agent run. Telemetry/debug
 		// hooks installed in production are the most likely source of
@@ -333,14 +354,13 @@ func (o *Orchestrator) RunAgent(ctx context.Context, cfg AgentConfig) (*AgentRes
 			o.routerObserver(router)
 		}()
 	}
-	mailbox := NewInMemoryMailboxStore()
-	router.SetMailbox(mailbox)
-	primaryStepID := agentPrimaryStepID(runID)
-	router.RegisterStep(primaryStepID)
-	router.RegisterInbox(primaryStepID)
+	mailbox := ms.mailbox
+	primaryStepID := ms.primaryStepID
 	defer func() {
 		// Close the primary inbox so the per-call mailbox does not
-		// retain dangling open-step state across calls.
+		// retain dangling open-step state across calls. A SendMessage
+		// arriving after this point drops with target-terminal, which
+		// the consumer reads as "agent done - resurrect instead".
 		router.Close(primaryStepID)
 	}()
 
@@ -401,12 +421,11 @@ func (o *Orchestrator) RunAgent(ctx context.Context, cfg AgentConfig) (*AgentRes
 
 	// Per-call router/mailbox are populated on the runner so the
 	// runner observes inter-agent messages addressed to primaryStepID.
-	// Wake gives the runner a wake channel symmetric to the executor's
-	// per-step wiring; for the standalone RunAgent path no
-	// DeliveryEngine watches the mailbox, but the channel is allocated
-	// so the runner's mailbox-mode predicates (Mailbox+Wake non-nil)
-	// can engage if a future engine is introduced.
-	wake := make(chan struct{}, 1)
+	// Wake gives the runner a wake channel: AgentHandle.SendMessage
+	// appends to the mailbox and signals this channel directly, so a
+	// user message reaches a still-running agent at its next turn
+	// boundary without needing a DeliveryEngine on the standalone path.
+	wake := ms.wake
 	runnerOpts := []AgentRunnerOption{
 		WithRunnerModel(o.model),
 		WithRunnerTools(effectiveTools...),
@@ -418,6 +437,19 @@ func (o *Orchestrator) RunAgent(ctx context.Context, cfg AgentConfig) (*AgentRes
 		WithRunnerMailbox(mailbox),
 		WithRunnerWake(wake),
 		WithRunnerRouter(router),
+	}
+	// Persist the standalone agent's transcript so a finished agent can
+	// be resurrected: the consumer loads (runID, primaryStepID) from
+	// the store and respawns with cfg.InitialMessages. Without this the
+	// RunAgent path keeps no transcript and resurrection is impossible.
+	if o.transcriptStoreFactory != nil {
+		runnerOpts = append(runnerOpts, WithRunnerTranscript(o.transcriptStoreFactory()))
+	}
+	// InitialMessages (resurrection): prepend the saved transcript
+	// before the new user prompt so the respawned agent sees the full
+	// prior conversation.
+	if len(cfg.InitialMessages) > 0 {
+		runnerOpts = append(runnerOpts, WithRunnerInitialMessages(cfg.InitialMessages))
 	}
 	if o.streaming {
 		runnerOpts = append(runnerOpts, WithRunnerStreaming())

--- a/internal/spec/types.go
+++ b/internal/spec/types.go
@@ -120,6 +120,16 @@ type AgentConfig struct {
 	// single-session key ("" bucket); consumers must populate it
 	// for multi-session deployments.
 	SessionID string `json:"-" yaml:"-"`
+
+	// InitialMessages pre-loads a saved conversation transcript that
+	// the agent loop prepends BEFORE the new user prompt. Empty / nil
+	// → the agent starts cold from `Prompt` alone. Non-empty → the
+	// agent resumes with the full prior context (resurrection: a
+	// consumer respawns a finished agent with its loaded transcript
+	// plus a new user message). Forwarded verbatim to the AgentRunner
+	// via WithRunnerInitialMessages on the RunAgent / RunAgentAsync
+	// path. Per-call only; never read from workflow YAML.
+	InitialMessages []provider.Message `json:"-" yaml:"-"`
 }
 
 // Step is a single node in the workflow DAG. Stable.


### PR DESCRIPTION
Adds the zenflow surface needed to chat with a running or finished standalone agent.

## What

- `AgentConfig.InitialMessages` — a per-call saved transcript that `RunAgent`/`RunAgentAsync` prepend before the new user prompt, so a finished agent can be resurrected with its full prior context.
- Standalone `RunAgent` now wires `WithRunnerTranscript` from the orchestrator transcript-store factory; the agent's conversation is persisted (keyed by runID + primary step ID) and loadable for resurrection. Previously the `RunAgent` path kept no transcript.
- `AgentHandle.SendMessage` delivers a user message into a running agent's mailbox and signals its wake channel: `queued: <step>` on success, `dropped: target-terminal` once the agent has finished.
- `AgentHandle.RunID` / `PrimaryStepID` expose the transcript key.

## How

The per-call router, mailbox, wake channel and primary step ID are bundled into an `agentMessaging` value built by `RunAgentAsync` up front and shared with the inner `runAgent` call, so the handle and the run agree on one substrate. The `runAgentAsyncRunner` test seam is unchanged: the substrate rides the run context.

## Test

`go build ./...` clean; `go test ./internal/exec/` PASS.