### PR TITLE
fix(exec): populate Timestamp on plan_ready events

### DIFF
--- a/internal/exec/zenflow.go
+++ b/internal/exec/zenflow.go
@@ -572,6 +572,9 @@ func (o *Orchestrator) RunFlow(ctx context.Context, wf *Workflow, opts ...RunFlo
 // plan_ready emit, which fires before wrapProgressNonBlocking
 // installs its pump-level recover.
 func emitPlanReady(ctx context.Context, sink ProgressSink, ev Event) {
+	if ev.Timestamp.IsZero() {
+		ev.Timestamp = time.Now()
+	}
 	defer func() {
 		if r := recover(); r != nil {
 			slog.Warn("panic in ProgressSink.OnEvent (plan_ready)",

--- a/internal/exec/zenflow_test.go
+++ b/internal/exec/zenflow_test.go
@@ -1083,6 +1083,9 @@ func TestRunFlow_EmitsPlanReadyBeforeExecute(t *testing.T) {
 	if gotWf != wf {
 		t.Fatalf("EventPlanReady workflow does not match input: got=%p want=%p", gotWf, wf)
 	}
+	if found.Timestamp.IsZero() {
+		t.Fatalf("EventPlanReady has zero Timestamp")
+	}
 }
 
 // TestRunAgent_StreamingVerbose exercises the WithRunnerStreaming and


### PR DESCRIPTION
## Summary
- `emitPlanReady` now defaults `ev.Timestamp` to `time.Now()` when zero, so the pre-executor `plan_ready` event no longer surfaces `0001-01-01 00:00:00 UTC` to sinks
- Root cause: both `RunFlow` and `RunGoal` constructed the `Event` literal without a `Timestamp` field; fixing inside the helper covers any future caller too
- Added regression assertion in `TestRunFlow_EmitsPlanReadyBeforeExecute`

Fixes #5

## Test plan
- [x] `go test ./internal/exec/ -run TestRunFlow_EmitsPlanReadyBeforeExecute -count=1`
- [x] `go test ./internal/exec/ -count=1`
- [x] `go build ./...`