### PR TITLE
feat: goai v0.8.1, NewTool migration, reasoning-model sampling strip, example fixes

### DIFF
--- a/cmd/zenflow/tool/bash.go
+++ b/cmd/zenflow/tool/bash.go
@@ -3,7 +3,6 @@ package tool
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"io"
 	"os/exec"
 	"time"
@@ -21,20 +20,13 @@ const (
 func bashTool() goai.Tool { return bashToolIn("") }
 
 func bashToolIn(workdir string) goai.Tool {
-	return goai.Tool{
-		Name:        "bash",
-		Description: "Execute a shell command and return its combined stdout and stderr. WARNING: bash is unsandboxed - the command runs with the same privileges as the host process. When a workdir is configured, the LLM-supplied working_directory is ignored and the command is forced to run in the workdir; this does NOT prevent the shell itself from `cd ..`-ing or writing to absolute paths during the command.",
-		InputSchema: json.RawMessage(`{"type":"object","properties":{"command":{"type":"string","description":"The shell command to execute"},"timeout_seconds":{"type":"integer","description":"Per-command timeout in seconds (default 30, max 300)"},"working_directory":{"type":"string","description":"Working directory for the command (ignored when a workdir sandbox is configured)"}},"required":["command"]}`),
-		Execute: func(ctx context.Context, args json.RawMessage) (string, error) {
-			var p struct {
-				Command          string `json:"command"`
-				TimeoutSeconds   int    `json:"timeout_seconds"`
-				WorkingDirectory string `json:"working_directory"`
-			}
-			if err := json.Unmarshal(args, &p); err != nil {
-				return "", err
-			}
-
+	return goai.NewTool("bash",
+		"Execute a shell command and return its combined stdout and stderr. WARNING: bash is unsandboxed - the command runs with the same privileges as the host process. When a workdir is configured, the LLM-supplied working_directory is ignored and the command is forced to run in the workdir; this does NOT prevent the shell itself from `cd ..`-ing or writing to absolute paths during the command.",
+		func(ctx context.Context, p struct {
+			Command          string `json:"command" jsonschema:"description=The shell command to execute"`
+			TimeoutSeconds   int    `json:"timeout_seconds" jsonschema:"description=Per-command timeout in seconds (default 30; max 300)"`
+			WorkingDirectory string `json:"working_directory" jsonschema:"description=Working directory for the command (ignored when a workdir sandbox is configured)"`
+		}) (string, error) {
 			// Apply per-invocation timeout (capped at 300s).
 			// (2026-05-04) - cap BEFORE the multiplication.
 			// `time.Duration(p.TimeoutSeconds) * time.Second` overflows
@@ -94,8 +86,7 @@ func bashToolIn(workdir string) goai.Tool {
 				return combined + err.Error(), nil
 			}
 			return combined, nil
-		},
-	}
+		})
 }
 
 // limitedWriter wraps a writer and stops writing after a byte limit.

--- a/cmd/zenflow/tool/glob.go
+++ b/cmd/zenflow/tool/glob.go
@@ -2,7 +2,6 @@ package tool
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -16,18 +15,11 @@ import (
 // validated through resolveUnderWorkdir so symlinks that point outside workdir
 // are also filtered out.
 func globToolIn(workdir string) goai.Tool {
-	return goai.Tool{
-		Name:        "glob",
-		Description: "Search for files matching a glob pattern. When a workdir is configured, the pattern is relative to the workdir and cannot escape it.",
-		InputSchema: json.RawMessage(`{"type":"object","properties":{"pattern":{"type":"string","description":"The glob pattern to match (relative to workdir when a workdir is configured)"}},"required":["pattern"]}`),
-		Execute: func(_ context.Context, args json.RawMessage) (string, error) {
-			var p struct {
-				Pattern string `json:"pattern"`
-			}
-			if err := json.Unmarshal(args, &p); err != nil {
-				return "", err
-			}
-
+	return goai.NewTool("glob",
+		"Search for files matching a glob pattern. When a workdir is configured, the pattern is relative to the workdir and cannot escape it.",
+		func(_ context.Context, p struct {
+			Pattern string `json:"pattern" jsonschema:"description=The glob pattern to match (relative to workdir when a workdir is configured)"`
+		}) (string, error) {
 			if workdir == "" {
 				// Legacy / unconstrained mode.
 				matches, err := filepath.Glob(p.Pattern)
@@ -62,6 +54,5 @@ func globToolIn(workdir string) goai.Tool {
 				}
 			}
 			return strings.Join(safe, "\n"), nil
-		},
-	}
+		})
 }

--- a/cmd/zenflow/tool/grep.go
+++ b/cmd/zenflow/tool/grep.go
@@ -3,7 +3,6 @@ package tool
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
@@ -22,20 +21,13 @@ const grepMaxOutput = 1 << 20 // 1 MB
 // Windows uses PowerShell Select-String. Both produce equivalent output
 // (file:line:content lines) and honour the same input JSON schema.
 func grepToolIn(workdir string) goai.Tool {
-	return goai.Tool{
-		Name:        "grep",
-		Description: "Search for a pattern in files. Returns matching lines with file names and line numbers. Uses fixed-string matching by default; set regex=true for regex patterns. When a workdir is configured, the search path must be within the workdir.",
-		InputSchema: json.RawMessage(`{"type":"object","properties":{"pattern":{"type":"string","description":"The pattern to search for"},"path":{"type":"string","description":"The file or directory to search in (relative to workdir when a workdir is configured)"},"regex":{"type":"boolean","description":"Use regex matching instead of fixed-string (default: false)"}},"required":["pattern","path"]}`),
-		Execute: func(ctx context.Context, args json.RawMessage) (string, error) {
-			var p struct {
-				Pattern string `json:"pattern"`
-				Path    string `json:"path"`
-				Regex   bool   `json:"regex"`
-			}
-			if err := json.Unmarshal(args, &p); err != nil {
-				return "", err
-			}
-
+	return goai.NewTool("grep",
+		"Search for a pattern in files. Returns matching lines with file names and line numbers. Uses fixed-string matching by default; set regex=true for regex patterns. When a workdir is configured, the search path must be within the workdir.",
+		func(ctx context.Context, p struct {
+			Pattern string `json:"pattern" jsonschema:"description=The pattern to search for"`
+			Path    string `json:"path" jsonschema:"description=The file or directory to search in (relative to workdir when a workdir is configured)"`
+			Regex   bool   `json:"regex" jsonschema:"description=Use regex matching instead of fixed-string (default: false)"`
+		}) (string, error) {
 			// Resolve and validate the search path against workdir.
 			searchPath := p.Path
 			if workdir != "" {
@@ -83,6 +75,5 @@ func grepToolIn(workdir string) goai.Tool {
 				return combined, nil
 			}
 			return combined, nil
-		},
-	}
+		})
 }

--- a/cmd/zenflow/tool/read.go
+++ b/cmd/zenflow/tool/read.go
@@ -2,7 +2,6 @@ package tool
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -18,17 +17,11 @@ var readAll = io.ReadAll
 func readTool() goai.Tool { return readToolIn("") }
 
 func readToolIn(workdir string) goai.Tool {
-	return goai.Tool{
-		Name:        "read",
-		Description: "Read the contents of a file at the given path (capped at 1 MB). Rejects paths that resolve outside the configured workdir.",
-		InputSchema: json.RawMessage(`{"type":"object","properties":{"path":{"type":"string","description":"The file path to read"}},"required":["path"]}`),
-		Execute: func(_ context.Context, args json.RawMessage) (string, error) {
-			var p struct {
-				Path string `json:"path"`
-			}
-			if err := json.Unmarshal(args, &p); err != nil {
-				return "", err
-			}
+	return goai.NewTool("read",
+		"Read the contents of a file at the given path (capped at 1 MB). Rejects paths that resolve outside the configured workdir.",
+		func(_ context.Context, p struct {
+			Path string `json:"path" jsonschema:"description=The file path to read"`
+		}) (string, error) {
 			// normalize path separators so a Windows caller
 			// passing `subdir/file.txt` works the same as
 			// `subdir\file.txt`. Containment + workdir join already
@@ -56,6 +49,5 @@ func readToolIn(workdir string) goai.Tool {
 				return string(data[:readMaxSize]), fmt.Errorf("file exceeds 1 MB limit (truncated)")
 			}
 			return string(data), nil
-		},
-	}
+		})
 }

--- a/cmd/zenflow/tool/write.go
+++ b/cmd/zenflow/tool/write.go
@@ -2,7 +2,6 @@ package tool
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -14,19 +13,12 @@ import (
 func writeTool() goai.Tool { return writeToolIn("") }
 
 func writeToolIn(workdir string) goai.Tool {
-	return goai.Tool{
-		Name:        "write",
-		Description: "Write content to a file at the given path. Creates parent directories as needed. Rejects paths containing '..' traversal or that resolve outside the configured workdir.",
-		InputSchema: json.RawMessage(`{"type":"object","properties":{"path":{"type":"string","description":"The file path to write"},"content":{"type":"string","description":"The content to write"}},"required":["path","content"]}`),
-		Execute: func(_ context.Context, args json.RawMessage) (string, error) {
-			var p struct {
-				Path    string `json:"path"`
-				Content string `json:"content"`
-			}
-			if err := json.Unmarshal(args, &p); err != nil {
-				return "", err
-			}
-
+	return goai.NewTool("write",
+		"Write content to a file at the given path. Creates parent directories as needed. Rejects paths containing '..' traversal or that resolve outside the configured workdir.",
+		func(_ context.Context, p struct {
+			Path    string `json:"path" jsonschema:"description=The file path to write"`
+			Content string `json:"content" jsonschema:"description=The content to write"`
+		}) (string, error) {
 			// Reject path traversal: check raw path for ".." components before cleaning.
 			for part := range strings.SplitSeq(filepath.ToSlash(p.Path), "/") {
 				if part == ".." {
@@ -51,6 +43,5 @@ func writeToolIn(workdir string) goai.Tool {
 				return "", err
 			}
 			return "ok", nil
-		},
-	}
+		})
 }

--- a/docs/concepts/tools.md
+++ b/docs/concepts/tools.md
@@ -42,44 +42,32 @@ For full flag references (`bash` working directory, `grep` flags, `read` byte li
 
 ## Library-supplied tools
 
-When using zenflow as a Go library, you register tools via `WithTools`. A tool is just a `goai.Tool`:
+When using zenflow as a Go library, you register tools via `WithTools`. A tool is just a `goai.Tool`. The simplest way to build one is `goai.NewTool`, which generates the JSON Schema from your input struct and unmarshals arguments for you:
 
 ```go
 import (
     "context"
-    "encoding/json"
 
     "github.com/zendev-sh/goai"
     "github.com/zendev-sh/zenflow"
 )
 
-httpGet := goai.Tool{
-    Name:        "http_get",
-    Description: "Fetch a URL and return the response body.",
-    InputSchema: json.RawMessage(`{
-        "type": "object",
-        "required": ["url"],
-        "properties": {
-            "url": {"type": "string"}
-        }
-    }`),
-    Execute: func(ctx context.Context, raw json.RawMessage) (string, error) {
-        var args struct {
-            URL string `json:"url"`
-        }
-        if err := json.Unmarshal(raw, &args); err != nil {
-            return "", err
-        }
+httpGet := goai.NewTool("http_get",
+    "Fetch a URL and return the response body.",
+    func(ctx context.Context, args struct {
+        URL string `json:"url" jsonschema:"description=The URL to fetch"`
+    }) (string, error) {
         // ... do the HTTP call, return the body or an error string.
         return body, nil
-    },
-}
+    })
 
 orch := zenflow.New(
     zenflow.WithModel(llm),
     zenflow.WithTools(httpGet, otherTool, ...),
 )
 ```
+
+`NewTool` derives a strict-mode schema: every field of the input struct is `required` and `additionalProperties` is `false`. Use the `jsonschema` struct tag for per-field `description=...` and `enum=a|b|c` (descriptions must not contain commas - the tag parser uses commas to separate `description` from `enum`). For a schema shape `NewTool` cannot express, fall back to the raw `goai.Tool{Name, Description, InputSchema, Execute}` struct literal with a hand-written `InputSchema`.
 
 The same tool surface [goai](https://goai.sh) uses everywhere. Zenflow does not wrap or extend `goai.Tool` - what works in [goai](https://goai.sh) works in zenflow. See [goai tools docs](https://goai.sh) for the complete API.
 

--- a/docs/public/llms-full.txt
+++ b/docs/public/llms-full.txt
@@ -53,7 +53,10 @@ shell, no package manager.
 docker pull ghcr.io/zendev-sh/zenflow:latest
 
 # Run a workflow with the cwd mounted
-docker run --rm -e GEMINI_API_KEY -v "$PWD":/wd -w /wd \
+docker run --rm \
+  -e GEMINI_API_KEY \
+  -e ZENFLOW_MODEL=google/gemini-2.0-flash \
+  -v "$PWD":/wd -w /wd \
   ghcr.io/zendev-sh/zenflow:latest flow workflow.yaml
 ```
 
@@ -84,6 +87,19 @@ go install github.com/zendev-sh/zenflow/cmd/zenflow@latest
 
 Pin a specific version with `@v0.1.0-pre` instead of `@latest`. The
 binary lands in `$(go env GOPATH)/bin`. Requires Go 1.25+.
+
+The default `go install` build excludes the OpenTelemetry runtime
+to keep dependency closures small; the `--trace` CLI flag becomes a
+runtime no-op. To get a binary with `--trace` wired to the OTel
+exporter, install with the build tag instead:
+
+```bash
+go install -tags otel github.com/zendev-sh/zenflow/cmd/zenflow@latest
+```
+
+The pre-built binaries shipped via the install script, Homebrew, and
+Docker images all carry `-tags otel` already, so `--trace` works out
+of the box on those paths.
 
 ## Manual download
 
@@ -4129,44 +4145,32 @@ For full flag references (`bash` working directory, `grep` flags, `read` byte li
 
 ## Library-supplied tools
 
-When using zenflow as a Go library, you register tools via `WithTools`. A tool is just a `goai.Tool`:
+When using zenflow as a Go library, you register tools via `WithTools`. A tool is just a `goai.Tool`. The simplest way to build one is `goai.NewTool`, which generates the JSON Schema from your input struct and unmarshals arguments for you:
 
 ```go
 import (
     "context"
-    "encoding/json"
 
     "github.com/zendev-sh/goai"
     "github.com/zendev-sh/zenflow"
 )
 
-httpGet := goai.Tool{
-    Name:        "http_get",
-    Description: "Fetch a URL and return the response body.",
-    InputSchema: json.RawMessage(`{
-        "type": "object",
-        "required": ["url"],
-        "properties": {
-            "url": {"type": "string"}
-        }
-    }`),
-    Execute: func(ctx context.Context, raw json.RawMessage) (string, error) {
-        var args struct {
-            URL string `json:"url"`
-        }
-        if err := json.Unmarshal(raw, &args); err != nil {
-            return "", err
-        }
+httpGet := goai.NewTool("http_get",
+    "Fetch a URL and return the response body.",
+    func(ctx context.Context, args struct {
+        URL string `json:"url" jsonschema:"description=The URL to fetch"`
+    }) (string, error) {
         // ... do the HTTP call, return the body or an error string.
         return body, nil
-    },
-}
+    })
 
 orch := zenflow.New(
     zenflow.WithModel(llm),
     zenflow.WithTools(httpGet, otherTool, ...),
 )
 ```
+
+`NewTool` derives a strict-mode schema: every field of the input struct is `required` and `additionalProperties` is `false`. Use the `jsonschema` struct tag for per-field `description=...` and `enum=a|b|c` (descriptions must not contain commas - the tag parser uses commas to separate `description` from `enum`). For a schema shape `NewTool` cannot express, fall back to the raw `goai.Tool{Name, Description, InputSchema, Execute}` struct literal with a hand-written `InputSchema`.
 
 The same tool surface [goai](https://goai.sh) uses everywhere. Zenflow does not wrap or extend `goai.Tool` - what works in [goai](https://goai.sh) works in zenflow. See [goai tools docs](https://goai.sh) for the complete API.
 
@@ -8557,7 +8561,6 @@ orch := zenflow.New(
 )
 ```
 
-For dynamic toggling, the deprecated `WithStreamingBool(enabled bool)` shim accepts a bool but will be removed before v1.0.
 
 ### `WithVerbose`
 
@@ -8578,7 +8581,6 @@ orch := zenflow.New(
 )
 ```
 
-For dynamic toggling, the deprecated `WithVerboseBool(enabled bool)` shim accepts a bool but will be removed before v1.0.
 
 ### `WithOutputTransform`
 
@@ -8728,10 +8730,10 @@ result, err := orch.RunGoal(ctx,
 A few options exist for advanced use cases or testing infrastructure:
 
 - **`WithMailboxStore(factory)`** - replace the default `InMemoryMailboxStore` with a custom backend (e.g., SQLite for multi-process workflows). Factory is invoked once per run.
-- **`WithMailboxDelivery()` / `WithoutMailboxDelivery()`** - toggle the entire mailbox + delivery engine stack. Defaults to enabled. Mostly used by tests that exercise the scheduler path without messaging machinery. Deprecated `WithMailboxDeliveryBool(enabled bool)` shim accepts a bool but will be removed before v1.0.
+- **`WithMailboxDelivery()` / `WithoutMailboxDelivery()`** - toggle the entire mailbox + delivery engine stack. Defaults to enabled. Mostly used by tests that exercise the scheduler path without messaging machinery.
 - **`WithExternalInbox(ids...)`** - pre-register non-step sender inboxes (e.g., `"coordinator"`) on the MessageRouter so reverse-routed responses don't drop with `DropReasonUnknownStep`.
 - **`WithModelResolver(r)`** - install a `ModelResolver` consulted by the resume path when a saved transcript references a model identifier different from the executor's default.
-- **`WithTruncationOnCapReached()` / `WithoutTruncationOnCapReached()`** - configure the resume path to fall back to a truncated load when a sealed transcript hits its cap. Default disabled (sealed transcripts fail the resume loudly). Deprecated `WithTruncationOnCapReachedBool(enabled bool)` shim accepts a bool but will be removed before v1.0.
+- **`WithTruncationOnCapReached()` / `WithoutTruncationOnCapReached()`** - configure the resume path to fall back to a truncated load when a sealed transcript hits its cap. Default disabled (sealed transcripts fail the resume loudly).
 - **`WithRunID(runID string)`** - pin the orchestrator's run identifier. Without this, zenflow generates a fresh ID internally; useful when an HTTP server has already returned a run ID to the caller and needs the emitted events to carry the same ID.
 
 ## Coordinator-loop options

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/google/cel-go v0.27.0
-	github.com/zendev-sh/goai v0.7.6
+	github.com/zendev-sh/goai v0.8.1
 	github.com/zendev-sh/zenflow/observability/otel v0.1.4
 	go.uber.org/goleak v1.3.0
 	golang.org/x/text v0.35.0
@@ -21,7 +21,7 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 // indirect
-	github.com/zendev-sh/goai/observability/otel v0.7.6 // indirect
+	github.com/zendev-sh/goai/observability/otel v0.8.1 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel v1.43.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.43.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -35,12 +35,10 @@ github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0t
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-github.com/zendev-sh/goai v0.7.6 h1:O8SomDm28SBQPjpfT4eAM453THBxydP9IfHpX15E8sA=
-github.com/zendev-sh/goai v0.7.6/go.mod h1:64KI8qD64Z/z+2bx4g1yjNDPVORWWN58lNWIYye6S80=
-github.com/zendev-sh/goai/observability/otel v0.7.6 h1:Fr4ih3jSxnsAhhap8SDvhDCnCkhxKk/AyglzSXV+wdU=
-github.com/zendev-sh/goai/observability/otel v0.7.6/go.mod h1:caCoMqnjLjVDzP01Sxbo9BLGIjjbKHFglWfxmJdtPm8=
-github.com/zendev-sh/zenflow/observability/otel v0.1.3 h1:6lB1sbjC9O3DHcPNvuDELqR/Rk1uwMalc5sjUBOjtgg=
-github.com/zendev-sh/zenflow/observability/otel v0.1.3/go.mod h1:BuJQ2b0NMH1KYCvzN8nRjvUDpVd0vRQOGjgl+K59fZc=
+github.com/zendev-sh/goai v0.8.1 h1:f+nNG6rW5IRcTaeXG92SPszy5dx0kKoY/4cQX/1t8Ik=
+github.com/zendev-sh/goai v0.8.1/go.mod h1:64KI8qD64Z/z+2bx4g1yjNDPVORWWN58lNWIYye6S80=
+github.com/zendev-sh/goai/observability/otel v0.8.1 h1:ybcvlhN4wYTj9Lbp9MuS52CTB7GZT7hTxUnpOS6MDRU=
+github.com/zendev-sh/goai/observability/otel v0.8.1/go.mod h1:caCoMqnjLjVDzP01Sxbo9BLGIjjbKHFglWfxmJdtPm8=
 github.com/zendev-sh/zenflow/observability/otel v0.1.4 h1:B9S1e2nRKtjWJIdCwc08VIj+2oaJpMhzdrFtfETj86M=
 github.com/zendev-sh/zenflow/observability/otel v0.1.4/go.mod h1:BuJQ2b0NMH1KYCvzN8nRjvUDpVd0vRQOGjgl+K59fZc=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=

--- a/internal/coord/coord_tools.go
+++ b/internal/coord/coord_tools.go
@@ -2,7 +2,6 @@ package coord
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -68,28 +67,32 @@ var (
 // the runner so a single monotonic sequence spans every coord-side
 // routing tool call within a workflow.
 
-// forwardArgs is the JSON payload accepted by forward_to_agent.
+// forwardArgs is the JSON payload accepted by forward_to_agent. The
+// jsonschema tags drive goai.SchemaFrom; under v0.8.0's strict-mode
+// schema generation every field is required and additionalProperties is
+// false, so `kind` is now always supplied (unknown/empty values still
+// fall back to "info" via kindToRouterMessageType).
 type forwardArgs struct {
-	TargetStepID string `json:"target_step_id"`
-	Text         string `json:"text"`
-	Kind         string `json:"kind"` // optional: "info" (default), "context_update", "cancel"
+	TargetStepID string `json:"target_step_id" jsonschema:"description=The stepID of the agent to receive the message (must be a registered workflow step)."`
+	Text         string `json:"text" jsonschema:"description=Message text to deliver."`
+	Kind         string `json:"kind" jsonschema:"description=Optional message kind. Defaults to 'info'. Unknown values fall back to 'info' rather than erroring.,enum=info|context_update|cancel"`
 }
 
 // narrateArgs is the JSON payload accepted by narrate.
 type narrateArgs struct {
-	Text string `json:"text"`
+	Text string `json:"text" jsonschema:"description=The narration text to surface to the user."`
 }
 
 // finalizeArgs is the JSON payload accepted by finalize.
 type finalizeArgs struct {
-	Summary string `json:"summary"` // optional: synthesis text the caller may surface as EventCoordinatorSynthesis
+	Summary string `json:"summary" jsonschema:"description=Optional final synthesis text the caller may surface as EventCoordinatorSynthesis."`
 }
 
 // sendMessageArgs is the JSON payload accepted by send_message. Per
 // D-Z1 there is NO `to` field - agents cannot select the destination;
 // the tool always routes to the canonical coord inbox key.
 type sendMessageArgs struct {
-	Text string `json:"text"`
+	Text string `json:"text" jsonschema:"description=Message text to send to the coordinator."`
 }
 
 // kindToRouterMessageType maps the LLM-visible "kind" string to the
@@ -135,15 +138,9 @@ func kindToRouterMessageType(kind string) router.MessageType {
 // surfaces as an Execute error; a router drop is a runtime routing
 // outcome and surfaces as a non-error tool-result string.
 func ForwardToAgentToolDef(runner RunnerHandle) goai.Tool {
-	return goai.Tool{
-		Name:        toolNameForwardToAgent,
-		Description: "Forward a message to a running step agent. Coordinator uses this to inject context, follow-up questions, or instructions into a sibling step's mailbox. Hub-to-spoke only - agents cannot reply directly via this tool. Use kind='context_update' for context injection, 'cancel' to request the recipient stop, or omit/use 'info' for general notes.",
-		InputSchema: json.RawMessage(`{"type":"object","properties":{"target_step_id":{"type":"string","description":"The stepID of the agent to receive the message (must be a registered workflow step)."},"text":{"type":"string","description":"Message text to deliver."},"kind":{"type":"string","enum":["info","context_update","cancel"],"description":"Optional message kind. Defaults to 'info'. Unknown values fall back to 'info' rather than erroring."}},"required":["target_step_id","text"]}`),
-		Execute: func(ctx context.Context, input json.RawMessage) (string, error) {
-			var args forwardArgs
-			if err := json.Unmarshal(input, &args); err != nil {
-				return "", fmt.Errorf("forward_to_agent: parse args: %w", err)
-			}
+	return goai.NewTool(toolNameForwardToAgent,
+		"Forward a message to a running step agent. Coordinator uses this to inject context, follow-up questions, or instructions into a sibling step's mailbox. Hub-to-spoke only - agents cannot reply directly via this tool. Use kind='context_update' for context injection, 'cancel' to request the recipient stop, or omit/use 'info' for general notes.",
+		func(ctx context.Context, args forwardArgs) (string, error) {
 			if args.TargetStepID == "" {
 				return "", ErrForwardTargetRequired
 			}
@@ -227,8 +224,7 @@ func ForwardToAgentToolDef(runner RunnerHandle) goai.Tool {
 				return err.Error(), nil
 			}
 			return "queued: " + id, nil
-		},
-	}
+		})
 }
 
 // BuildUnknownStepHint formats a helpful suffix listing currently
@@ -318,15 +314,9 @@ func emitMessageSent(ctx context.Context, runner RunnerHandle, to, text string, 
 // missing coord is a runtime routing outcome (the user opted out of
 // a coord), not a coord-side configuration bug.
 func SendMessageToolDef(runner RunnerHandle) goai.Tool {
-	return goai.Tool{
-		Name:        toolNameSendMessage,
-		Description: "Send a message to the workflow coordinator. Hub-only routing - agents cannot directly message siblings; the coordinator decides forwarding. Use this for status updates, questions, or requests for context the coordinator can route to other steps.",
-		InputSchema: json.RawMessage(`{"type":"object","properties":{"text":{"type":"string","description":"Message text to send to the coordinator."}},"required":["text"]}`),
-		Execute: func(ctx context.Context, input json.RawMessage) (string, error) {
-			var args sendMessageArgs
-			if err := json.Unmarshal(input, &args); err != nil {
-				return "", fmt.Errorf("send_message: parse args: %w", err)
-			}
+	return goai.NewTool(toolNameSendMessage,
+		"Send a message to the workflow coordinator. Hub-only routing - agents cannot directly message siblings; the coordinator decides forwarding. Use this for status updates, questions, or requests for context the coordinator can route to other steps.",
+		func(ctx context.Context, args sendMessageArgs) (string, error) {
 			if strings.TrimSpace(args.Text) == "" {
 				return "", ErrSendMessageEmpty
 			}
@@ -346,8 +336,7 @@ func SendMessageToolDef(runner RunnerHandle) goai.Tool {
 				return err.Error(), nil
 			}
 			return "queued: " + id, nil
-		},
-	}
+		})
 }
 
 // NarrateToolDef returns the `narrate` tool. The coord LLM calls it to
@@ -362,15 +351,9 @@ func SendMessageToolDef(runner RunnerHandle) goai.Tool {
 // Safety: when runner.Progress is nil the tool returns a clear
 // error. The coord must be wired with a sink before narrate can fire.
 func NarrateToolDef(runner RunnerHandle) goai.Tool {
-	return goai.Tool{
-		Name:        toolNameNarrate,
-		Description: "Emit a narration message for the user/observer. Coordinator uses this to explain reasoning, summarize step results, or surface user-facing context. Does NOT route to step agents - use forward_to_agent for that.",
-		InputSchema: json.RawMessage(`{"type":"object","properties":{"text":{"type":"string","description":"The narration text to surface to the user."}},"required":["text"]}`),
-		Execute: func(ctx context.Context, input json.RawMessage) (string, error) {
-			var args narrateArgs
-			if err := json.Unmarshal(input, &args); err != nil {
-				return "", fmt.Errorf("narrate: parse args: %w", err)
-			}
+	return goai.NewTool(toolNameNarrate,
+		"Emit a narration message for the user/observer. Coordinator uses this to explain reasoning, summarize step results, or surface user-facing context. Does NOT route to step agents - use forward_to_agent for that.",
+		func(ctx context.Context, args narrateArgs) (string, error) {
 			if strings.TrimSpace(args.Text) == "" {
 				return "", ErrNarrateEmpty
 			}
@@ -387,8 +370,7 @@ func NarrateToolDef(runner RunnerHandle) goai.Tool {
 				Message:   args.Text,
 			})
 			return "narrated", nil
-		},
-	}
+		})
 }
 
 // FinalizeToolDef returns the `finalize` tool. The coord LLM calls it
@@ -407,18 +389,11 @@ func NarrateToolDef(runner RunnerHandle) goai.Tool {
 // CLI usage the loop also surfaces runner.FinalSummary as
 // EventCoordinatorSynthesis before disposing the runner.
 func FinalizeToolDef(runner RunnerHandle) goai.Tool {
-	return goai.Tool{
-		Name:        toolNameFinalize,
-		Description: "Signal that coordination is complete. The caller's Run loop should exit after this tool returns. Coordinator MUST call this explicitly when it is done routing/narrating - there is no implicit finalization. Optional 'summary' carries the final synthesis text for the caller to surface as EventCoordinatorSynthesis.",
-		InputSchema: json.RawMessage(`{"type":"object","properties":{"summary":{"type":"string","description":"Optional final synthesis text the caller may surface as EventCoordinatorSynthesis."}}}`),
-		Execute: func(_ context.Context, input json.RawMessage) (string, error) {
-			var args finalizeArgs
-			if err := json.Unmarshal(input, &args); err != nil {
-				return "", fmt.Errorf("finalize: parse args: %w", err)
-			}
+	return goai.NewTool(toolNameFinalize,
+		"Signal that coordination is complete. The caller's Run loop should exit after this tool returns. Coordinator MUST call this explicitly when it is done routing/narrating - there is no implicit finalization. Optional 'summary' carries the final synthesis text for the caller to surface as EventCoordinatorSynthesis.",
+		func(_ context.Context, args finalizeArgs) (string, error) {
 			runner.SetFinalSummary(args.Summary)
 			runner.MarkFinalized()
 			return "finalized", nil
-		},
-	}
+		})
 }

--- a/internal/coord/coord_tools_test.go
+++ b/internal/coord/coord_tools_test.go
@@ -1,0 +1,80 @@
+package coord
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/zendev-sh/zenflow/internal/router"
+	"github.com/zendev-sh/zenflow/internal/types"
+)
+
+// stubRunner is a minimal RunnerHandle for exercising the coord tool
+// factories without a full AgentRunner. Router/Progress are nil so the
+// tools take their graceful no-wiring paths.
+type stubRunner struct {
+	finalized bool
+	summary   string
+}
+
+func (s *stubRunner) Router() *router.Router            { return nil }
+func (s *stubRunner) Progress() types.ProgressSink      { return nil }
+func (s *stubRunner) StepID() string                    { return "step" }
+func (s *stubRunner) RunID() string                     { return "run" }
+func (s *stubRunner) NextForwardSeq() uint64            { return 1 }
+func (s *stubRunner) EnsureFinalizeCh() <-chan struct{} { return nil }
+func (s *stubRunner) MarkFinalized()                    { s.finalized = true }
+func (s *stubRunner) SetFinalSummary(x string)          { s.summary = x }
+func (s *stubRunner) FinalSummary() string              { return s.summary }
+func (s *stubRunner) Finalized() bool                   { return s.finalized }
+
+func TestForwardToAgentToolDef_Execute(t *testing.T) {
+	r := &stubRunner{}
+	tool := ForwardToAgentToolDef(r)
+	if tool.Name != toolNameForwardToAgent {
+		t.Fatalf("name = %q", tool.Name)
+	}
+	// Missing target -> required error.
+	if _, err := tool.Execute(t.Context(), json.RawMessage(`{"target_step_id":""}`)); !errors.Is(err, ErrForwardTargetRequired) {
+		t.Errorf("empty target: want ErrForwardTargetRequired, got %v", err)
+	}
+	// Valid target with nil router -> dropped, no error.
+	got, err := tool.Execute(t.Context(), json.RawMessage(`{"target_step_id":"worker","text":"hi"}`))
+	if err != nil || got != "dropped: no-router" {
+		t.Errorf("nil router: got %q err=%v, want 'dropped: no-router'", got, err)
+	}
+}
+
+func TestSendMessageToolDef_Execute(t *testing.T) {
+	tool := SendMessageToolDef(&stubRunner{})
+	if _, err := tool.Execute(t.Context(), json.RawMessage(`{"text":"  "}`)); !errors.Is(err, ErrSendMessageEmpty) {
+		t.Errorf("empty text: want ErrSendMessageEmpty, got %v", err)
+	}
+	got, err := tool.Execute(t.Context(), json.RawMessage(`{"text":"status"}`))
+	if err != nil || got != "dropped: no-coordinator" {
+		t.Errorf("nil router: got %q err=%v, want 'dropped: no-coordinator'", got, err)
+	}
+}
+
+func TestNarrateToolDef_Execute(t *testing.T) {
+	tool := NarrateToolDef(&stubRunner{})
+	if _, err := tool.Execute(t.Context(), json.RawMessage(`{"text":""}`)); !errors.Is(err, ErrNarrateEmpty) {
+		t.Errorf("empty text: want ErrNarrateEmpty, got %v", err)
+	}
+	got, err := tool.Execute(t.Context(), json.RawMessage(`{"text":"note"}`))
+	if err != nil || got != "dropped: no-progress-sink" {
+		t.Errorf("nil progress: got %q err=%v, want 'dropped: no-progress-sink'", got, err)
+	}
+}
+
+func TestFinalizeToolDef_Execute(t *testing.T) {
+	r := &stubRunner{}
+	tool := FinalizeToolDef(r)
+	got, err := tool.Execute(t.Context(), json.RawMessage(`{"summary":"all done"}`))
+	if err != nil || got != "finalized" {
+		t.Fatalf("got %q err=%v, want 'finalized'", got, err)
+	}
+	if !r.finalized || r.summary != "all done" {
+		t.Errorf("finalize side effects: finalized=%v summary=%q", r.finalized, r.summary)
+	}
+}

--- a/internal/exec/agent_runner.go
+++ b/internal/exec/agent_runner.go
@@ -452,6 +452,35 @@ func (r *AgentRunner) Tools() []goai.Tool { return r.tools }
 // Stable.
 func (r *AgentRunner) Wake() chan struct{} { return r.wake }
 
+// reasoningModelPrefixes names the OpenAI reasoning families (o-series,
+// gpt-5 family, gpt-oss) that reject custom temperature / top_p. Consumed
+// by isReasoningModel.
+var reasoningModelPrefixes = []string{"o1", "o3", "o4", "gpt-5", "gpt-oss"}
+
+// isReasoningModel reports whether model names an OpenAI reasoning-family
+// model that rejects custom temperature / top_p. Any provider prefix is
+// stripped first ("azure/gpt-5.5" -> "gpt-5.5"), then the bare name is
+// matched against reasoningModelPrefixes (each prefix must be the whole name
+// or be followed by '-' or '.', so "o1" matches "o1" / "o1-mini" but not
+// "o1abc", and "gpt-5" matches "gpt-5" / "gpt-5.5" / "gpt-5-mini"). The
+// conversational "-chat" variants (e.g. gpt-5-chat) DO accept sampling
+// params and are deliberately excluded.
+func isReasoningModel(model string) bool {
+	m := strings.ToLower(strings.TrimSpace(model))
+	if i := strings.LastIndex(m, "/"); i >= 0 {
+		m = m[i+1:]
+	}
+	if strings.Contains(m, "chat") {
+		return false
+	}
+	for _, p := range reasoningModelPrefixes {
+		if m == p || (strings.HasPrefix(m, p) && (m[len(p)] == '-' || m[len(p)] == '.')) {
+			return true
+		}
+	}
+	return false
+}
+
 // Run executes the agent loop using goai.GenerateText with WithMaxSteps.
 // goai owns the tool loop. Zenflow hooks handle: permissions, agent spawning,
 // submit_result, and progress events. Inter-agent message delivery (when
@@ -752,10 +781,18 @@ func (r *AgentRunner) Run(ctx context.Context, cfg AgentConfig, userMessage stri
 	if r.stateRef != nil {
 		baseOpts = append(baseOpts, goai.WithStateRef(r.stateRef))
 	}
-	if cfg.Temperature != nil {
+	// Reasoning models (OpenAI o-series, gpt-5 family, gpt-oss) reject a
+	// non-default temperature / top_p with an HTTP 400. Drop those sampling
+	// params here so a workflow that sets them in YAML still runs on such a
+	// model (provider defaults apply) instead of hard-failing. The goal
+	// decomposer already nils these for coordinator-generated agents; this
+	// guard covers the flow / agent / loop-judge paths where the model is
+	// only known at run time.
+	reasoning := isReasoningModel(model)
+	if cfg.Temperature != nil && !reasoning {
 		baseOpts = append(baseOpts, goai.WithTemperature(*cfg.Temperature))
 	}
-	if cfg.TopP != nil {
+	if cfg.TopP != nil && !reasoning {
 		baseOpts = append(baseOpts, goai.WithTopP(*cfg.TopP))
 	}
 

--- a/internal/exec/agent_runner_reasoning_test.go
+++ b/internal/exec/agent_runner_reasoning_test.go
@@ -1,0 +1,79 @@
+package exec
+
+import (
+	"testing"
+
+	"github.com/zendev-sh/goai/provider"
+)
+
+func TestIsReasoningModel(t *testing.T) {
+	cases := map[string]bool{
+		// Reasoning families (provider-prefixed and bare).
+		"azure/gpt-5.5":          true,
+		"gpt-5":                  true,
+		"gpt-5.5-2026-04-24":     true,
+		"gpt-5-mini":             true,
+		"azure-deployment/gpt-5": true,
+		"openai/o3-mini":         true,
+		"o1":                     true,
+		"o4-mini":                true,
+		"gpt-oss-safeguard":      true,
+		"GPT-5.5":                true, // case-insensitive
+		"  azure/gpt-5.5  ":      true, // trimmed
+		// Not reasoning models.
+		"azure/gpt-5-chat":                       false, // chat variant accepts sampling
+		"gpt-5.2-chat-2026-02-10":                false,
+		"azure/gpt-4.1":                          false,
+		"google/gemini-2.5-flash":                false,
+		"bedrock/jp.anthropic.claude-sonnet-4-6": false,
+		"o1abc":                                  false, // no separator after prefix
+		"":                                       false,
+	}
+	for in, want := range cases {
+		if got := isReasoningModel(in); got != want {
+			t.Errorf("isReasoningModel(%q) = %v, want %v", in, got, want)
+		}
+	}
+}
+
+// TestRun_StripsSamplingForReasoningModel verifies the flow/agent path drops
+// temperature/top_p for reasoning models (which reject them) while preserving
+// them for ordinary models.
+func TestRun_StripsSamplingForReasoningModel(t *testing.T) {
+	temp := 0.9
+	topp := 0.5
+	cases := []struct {
+		name         string
+		model        string
+		wantStripped bool
+	}{
+		{"reasoning gpt-5.5 stripped", "azure/gpt-5.5", true},
+		{"reasoning o3-mini stripped", "openai/o3-mini", true},
+		{"gpt-5-chat preserved", "azure/gpt-5-chat", false},
+		{"normal model preserved", "google/gemini-2.5-flash", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			model := &mockModel{responses: []*provider.GenerateResult{textResult("ok", 1, 1)}}
+			r := &AgentRunner{model: model}
+			cfg := AgentConfig{Temperature: &temp, TopP: &topp, MaxTurns: 1}
+			if _, err := r.Run(t.Context(), cfg, "hi", tc.model, nil); err != nil {
+				t.Fatalf("run: %v", err)
+			}
+			calls := model.getCalls()
+			if len(calls) == 0 {
+				t.Fatal("no generate calls recorded")
+			}
+			gotTemp, gotTopP := calls[0].Temperature, calls[0].TopP
+			if tc.wantStripped {
+				if gotTemp != nil || gotTopP != nil {
+					t.Errorf("model %q: expected sampling stripped, got temp=%v topP=%v", tc.model, gotTemp, gotTopP)
+				}
+			} else {
+				if gotTemp == nil || gotTopP == nil {
+					t.Errorf("model %q: expected sampling preserved, got temp=%v topP=%v", tc.model, gotTemp, gotTopP)
+				}
+			}
+		})
+	}
+}

--- a/internal/exec/agent_tool.go
+++ b/internal/exec/agent_tool.go
@@ -40,14 +40,19 @@ func sanitizeAgentName(name string) string {
 	return cmp.Or(clean, "agent")
 }
 
+// agentToolParams is the JSON payload accepted by the agent tool. The
+// jsonschema tags drive goai.SchemaFrom (v0.8.0 strict-mode schema):
+// every field becomes required and additionalProperties is false. Field
+// descriptions must avoid commas - goai's tag parser splits on commas to
+// separate description from enum - so wording uses '/' and ';' instead.
 type agentToolParams struct {
-	Name            string   `json:"name"`
-	Description     string   `json:"description"`
-	Prompt          string   `json:"prompt"`
-	Tools           []string `json:"tools,omitempty"`
-	Model           string   `json:"model,omitempty"`
-	Instructions    string   `json:"instructions"`
-	RunInBackground bool     `json:"run_in_background"`
+	Name            string   `json:"name" jsonschema:"description=Short identifier for this child (alphanumeric/underscore/dash; matches Bedrock/OpenAI tool-name regex [a-zA-Z0-9_-]+)"`
+	Description     string   `json:"description" jsonschema:"description=Short description of the child's role (one sentence)"`
+	Prompt          string   `json:"prompt" jsonschema:"description=Role/persona prompt for the child"`
+	Tools           []string `json:"tools,omitempty" jsonschema:"description=Subset of parent's tool names the child may call. Omit or pass empty to inherit parent's full tool set."`
+	Model           string   `json:"model,omitempty" jsonschema:"description=OPTIONAL model identifier. OMIT this field entirely to inherit the parent's model. Do NOT pass strings like 'default' / 'auto' / 'gpt-4' unless that exact provider/model is configured - invalid identifiers fall back to the parent default but emit a warning."`
+	Instructions    string   `json:"instructions" jsonschema:"description=Specific task instructions for this invocation"`
+	RunInBackground bool     `json:"run_in_background" jsonschema:"description=If true the child launches async and returns immediately. Default false."`
 }
 
 // agentSpawner handles child agent creation and execution.
@@ -89,27 +94,12 @@ var _ childSpawner = (*agentSpawner)(nil)
 // and-forget. Backgrounded children deliver results to the inbox on
 // the parent's next turn.
 func AgentToolDef() goai.Tool {
-	return goai.Tool{
-		Name:        toolNameAgent,
-		Description: "Spawn a child agent to handle a focused subtask. The child runs with its own LLM context and returns its result string.",
-		InputSchema: json.RawMessage(`{
-			"type": "object",
-			"properties": {
-				"name": {"type": "string", "description": "Short identifier for this child (alphanumeric, underscore, dash; matches Bedrock/OpenAI tool-name regex [a-zA-Z0-9_-]+)"},
-				"description": {"type": "string", "description": "Short description of the child's role (one sentence)"},
-				"prompt": {"type": "string", "description": "Role/persona prompt for the child"},
-				"tools": {"type": "array", "items": {"type": "string"}, "description": "Subset of parent's tool names the child may call. Omit or pass empty to inherit parent's full tool set."},
-				"model": {"type": "string", "description": "OPTIONAL model identifier. OMIT this field entirely to inherit the parent's model. Do NOT pass strings like 'default', 'auto', or 'gpt-4' unless that exact provider/model is configured - invalid identifiers fall back to the parent default but emit a warning."},
-				"instructions": {"type": "string", "description": "Specific task instructions for this invocation"},
-				"run_in_background": {"type": "boolean", "description": "If true, launch async and return immediately. Default false."}
-			},
-			"required": ["name", "instructions"]
-		}`),
-		Execute: func(_ context.Context, _ json.RawMessage) (string, error) {
+	return goai.NewTool(toolNameAgent,
+		"Spawn a child agent to handle a focused subtask. The child runs with its own LLM context and returns its result string.",
+		func(_ context.Context, _ agentToolParams) (string, error) {
 			// No-op placeholder: actual dispatch handled by OnBeforeToolExecute hook in AgentRunner.
 			return "", ErrAgentToolDirectInvocation
-		},
-	}
+		})
 }
 
 // invalidModelHallucinations enumerates strings that LLMs commonly emit

--- a/internal/exec/agent_tool_test.go
+++ b/internal/exec/agent_tool_test.go
@@ -48,6 +48,16 @@ func TestAgentToolDef(t *testing.T) {
 	}
 }
 
+func TestAgentToolDef_ExecuteIsNoop(t *testing.T) {
+	// The agent tool is dispatched by the spawner hook; its Execute body is a
+	// no-op that returns the sentinel when invoked directly.
+	def := AgentToolDef()
+	_, err := def.Execute(t.Context(), []byte(`{"name":"x","instructions":"y"}`))
+	if !errors.Is(err, ErrAgentToolDirectInvocation) {
+		t.Fatalf("want ErrAgentToolDirectInvocation, got %v", err)
+	}
+}
+
 func TestAgentSpawner_SyncChild(t *testing.T) {
 	model := &mockModel{
 		responses: []*provider.GenerateResult{

--- a/internal/exec/shared_memory_tool.go
+++ b/internal/exec/shared_memory_tool.go
@@ -2,7 +2,6 @@ package exec
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	"github.com/zendev-sh/goai"
@@ -12,39 +11,25 @@ import (
 // under the given agentName namespace.
 func NewSharedMemoryTools(sm *SharedMemory, agentName string) []goai.Tool {
 	return []goai.Tool{
-		{
-			Name:        "shared_memory_write",
-			Description: "Write a key-value pair to shared memory. The key will be namespaced under your agent name.",
-			InputSchema: json.RawMessage(`{"type":"object","properties":{"key":{"type":"string","description":"Key name (will be namespaced under your agent name)"},"value":{"type":"string","description":"Value to store"}},"required":["key","value"]}`),
-			Execute: func(_ context.Context, args json.RawMessage) (string, error) {
-				var p struct {
-					Key   string `json:"key"`
-					Value string `json:"value"`
-				}
-				if err := json.Unmarshal(args, &p); err != nil {
-					return "", fmt.Errorf("shared_memory_write: invalid arguments: %w", err)
-				}
+		goai.NewTool("shared_memory_write",
+			"Write a key-value pair to shared memory. The key will be namespaced under your agent name.",
+			func(_ context.Context, p struct {
+				Key   string `json:"key" jsonschema:"description=Key name (will be namespaced under your agent name)"`
+				Value string `json:"value" jsonschema:"description=Value to store"`
+			}) (string, error) {
 				sm.Write(agentName, p.Key, p.Value)
 				return "ok", nil
-			},
-		},
-		{
-			Name:        "shared_memory_read",
-			Description: "Read a value from shared memory by fully qualified key.",
-			InputSchema: json.RawMessage(`{"type":"object","properties":{"key":{"type":"string","description":"Fully qualified key in 'agent/key' format"}},"required":["key"]}`),
-			Execute: func(_ context.Context, args json.RawMessage) (string, error) {
-				var p struct {
-					Key string `json:"key"`
-				}
-				if err := json.Unmarshal(args, &p); err != nil {
-					return "", fmt.Errorf("shared_memory_read: invalid arguments: %w", err)
-				}
+			}),
+		goai.NewTool("shared_memory_read",
+			"Read a value from shared memory by fully qualified key.",
+			func(_ context.Context, p struct {
+				Key string `json:"key" jsonschema:"description=Fully qualified key in 'agent/key' format"`
+			}) (string, error) {
 				val, ok := sm.Read(p.Key)
 				if !ok {
 					return "", fmt.Errorf("shared_memory_read: key %q not found", p.Key)
 				}
 				return val, nil
-			},
-		},
+			}),
 	}
 }

--- a/spec/v1/examples/loop-bidirectional.yaml
+++ b/spec/v1/examples/loop-bidirectional.yaml
@@ -24,6 +24,14 @@ agents:
     description: "Worker that performs a task, sends progress updates to coord via send_message, and reads coord context-updates from its inbox."
   judge:
     description: "Judge: stop after worker has reported progress on all 3 stages."
+    prompt: |
+      You are the termination judge for a 3-stage loop. The worker completes
+      ONE stage per iteration and reports it as "STAGE_<n>: ..." then replies
+      "STAGE_<n>_DONE". Your ONLY job is to count how many stages the worker
+      has reported in the iteration history below.
+      - If the history shows STAGE_3 has been reported, call submit_result with {"done": true}.
+      - If STAGE_3 has not appeared yet, call submit_result with {"done": false}.
+      Do NOT ask the worker to evaluate anything; you are only counting stages.
     resultSchema:
       type: object
       required: [done]

--- a/spec/v1/examples/loop-repeat-until.yaml
+++ b/spec/v1/examples/loop-repeat-until.yaml
@@ -23,6 +23,18 @@ agents:
     maxTurns: 10
   judge:
     description: "Judge agent that decides if the review cycle is complete. Set result.done=true when ready, result.done=false to continue."
+    prompt: |
+      You decide whether an iterative code-review cycle should STOP. Read the
+      iteration history below, focusing on the most recent implementation and
+      review. Call submit_result with {"done": true} when ANY of these hold:
+        - the latest review says the code is ready (e.g. "LGTM" or no issues), OR
+        - the implementation is functional and the review only raises minor or
+          stylistic nits (naming, comments, micro-optimizations), OR
+        - two or more review rounds have already passed and the remaining
+          feedback is not a correctness or compilation blocker.
+      Only return {"done": false} (with a one-line reason) when a genuine
+      functional or compilation bug remains in an early round. Prefer stopping
+      over endless polishing - do NOT keep looping on cosmetic feedback.
     model: "claude-sonnet-4-6"
     maxTurns: 3
     resultSchema:
@@ -53,7 +65,14 @@ steps:
           instructions: "Implement or fix the rate limiter based on review feedback."
         - id: review
           agent: reviewer
-          instructions: "Review the implementation. Output LGTM if ready, or list issues to fix."
+          instructions: |
+            Review the current implementation. If the code is functional and
+            broadly correct, reply with exactly "LGTM" on its own line - do NOT
+            block on minor, stylistic, or "nice to have" issues, and do not
+            demand extra features or tests. Only withhold "LGTM" (and then list
+            the specific defects) when there is a real correctness or
+            compilation bug. Bias strongly toward approving on the first or
+            second round; this is a demo loop, not a production gate.
           dependsOn:
             - implement
 

--- a/spec/v1/examples/retries-and-sampling.yaml
+++ b/spec/v1/examples/retries-and-sampling.yaml
@@ -2,18 +2,22 @@ name: retries-and-sampling
 version: 1
 description: |
   Demonstrates step-level and workflow-level maxRetries plus per-agent
-  sampling controls (temperature, topP). The step-level retries field is
-  the maximum attempt count after the first failure; the workflow-level
-  options.maxRetries acts as a default when step.maxRetries is unset.
+  sampling controls. The step-level retries field is the maximum attempt
+  count after the first failure; the workflow-level options.maxRetries acts
+  as a default when step.maxRetries is unset.
+
+  Sampling note: temperature and topP are alternative controls. Some
+  providers (e.g. Anthropic) reject requests that set BOTH at once, so this
+  example never combines them on a single agent - the drafter raises
+  temperature for variety; the judge demonstrates topP-only nucleus sampling.
 
 agents:
   drafter:
     description: "Drafts a brief response; uses higher temperature for variety."
     temperature: 0.9
-    topP: 0.95
   judge:
-    description: "Decides whether the draft is acceptable; deterministic."
-    temperature: 0.0
+    description: "Decides whether the draft is acceptable; uses topP-only nucleus sampling."
+    topP: 0.1
 
 options:
   maxRetries: 1


### PR DESCRIPTION
## Summary
- Bump **goai v0.7.6 → v0.8.1** (main + `observability/otel`).
- Adopt the new **`goai.NewTool[In]`** API for all fixed-schema tools (typed structs + `jsonschema` tags → auto schema + unmarshal). `submit_result` stays a struct literal (runtime schema).
- **Strip `temperature`/`top_p` for reasoning models** (o-series, gpt-5, gpt-oss) in `agent_runner.go` — they reject those params with HTTP 400. New `isReasoningModel` helper + unit/integration test.
- **Fix 3 spec examples** surfaced by a real-LLM matrix (google/bedrock/azure):
  - `loop-bidirectional.yaml` — explicit judge prompt so the until-agent converges (Gemini was exhausting).
  - `retries-and-sampling.yaml` — split temperature/topP across agents (the combined form is rejected by Anthropic).
  - `loop-repeat-until.yaml` — lenient reviewer + decisive judge prompt to fix non-convergence on weaker/slower models.
- `docs/concepts/tools.md` documents `NewTool`; `llms-full.txt` regenerated.

## Verification
- `go build ./...`, `go vet ./...`, full `go test ./...` (race detector) — all green.
- Real-LLM matrix re-run across the new model set (gemini-3-flash-preview, gemini-3.1-pro-preview, claude-sonnet-4-6, claude-haiku-4-5, gpt-4.1, gpt-5.5): all 3 fixed examples pass (gpt-5.5 passes once sampling is stripped + given adequate timeout).
- Note: `golangci-lint` not installed in the dev env, so the lint gate was not run locally.