### PR TITLE
fix: detect duplicate tool names in AgentRunner

### DIFF
--- a/internal/exec/agent_runner.go
+++ b/internal/exec/agent_runner.go
@@ -575,13 +575,34 @@ func (r *AgentRunner) Run(ctx context.Context, cfg AgentConfig, userMessage stri
 		}
 	}
 
-	// Auto-inject submit_result tool if agent has ResultSchema.
+	// Auto-inject submit_result tool if agent has ResultSchema and the caller
+	// has not already supplied a tool named "submit_result". Mirroring the
+	// send_message guard: a downstream caller can override the built-in tool
+	// (e.g. custom schema or description) without being silently shadowed or
+	// triggering the duplicate-name validation below.
 	var submitDone atomic.Bool
 	var submitResult atomic.Pointer[map[string]any]
 	var submitHandler *SubmitResultHandler
 	if cfg.ResultSchema != nil {
 		submitHandler = NewSubmitResultHandler(cfg.ResultSchema)
-		tools = append(tools[:len(tools):len(tools)], SubmitResultToolDef(cfg.ResultSchema))
+		hasSubmitResult := false
+		for _, t := range tools {
+			if t.Name == toolNameSubmitResult {
+				hasSubmitResult = true
+				break
+			}
+		}
+		if !hasSubmitResult {
+			tools = append(tools[:len(tools):len(tools)], SubmitResultToolDef(cfg.ResultSchema))
+		}
+	}
+
+	// Validate tool name uniqueness after all tool assembly (user-supplied
+	// tools, auto-injected send_message, auto-injected submit_result).
+	// Duplicates silently override each other in goai (last-wins), making
+	// bugs very hard to trace. Return a clear error instead.
+	if err := validateToolNames(tools); err != nil {
+		return nil, err
 	}
 
 	// Build initial user message (with attachments).

--- a/internal/exec/tools_validate.go
+++ b/internal/exec/tools_validate.go
@@ -1,0 +1,23 @@
+package exec
+
+import (
+	"fmt"
+
+	"github.com/zendev-sh/goai"
+)
+
+// validateToolNames returns an error if any two tools share the same name.
+// Duplicate tool names silently override each other in goai (last-wins),
+// making bugs very hard to trace. This check runs after all tool assembly
+// (user-supplied tools, auto-injected send_message, auto-injected
+// submit_result) so every source of duplicates is caught.
+func validateToolNames(tools []goai.Tool) error {
+	seen := make(map[string]struct{}, len(tools))
+	for _, t := range tools {
+		if _, exists := seen[t.Name]; exists {
+			return fmt.Errorf("zenflow: duplicate tool name %q: tool names must be unique", t.Name)
+		}
+		seen[t.Name] = struct{}{}
+	}
+	return nil
+}

--- a/internal/exec/tools_validate_test.go
+++ b/internal/exec/tools_validate_test.go
@@ -1,0 +1,74 @@
+package exec
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/zendev-sh/goai"
+	"github.com/zendev-sh/goai/provider"
+)
+
+// TestValidateToolNames_NoDuplicates verifies that a set of tools with
+// unique names passes validation without error.
+func TestValidateToolNames_NoDuplicates(t *testing.T) {
+	tools := []goai.Tool{
+		makeTool("read_file", "read a file", "content"),
+		makeTool("write_file", "write a file", "ok"),
+		makeTool("list_dir", "list a directory", "[]"),
+	}
+	if err := validateToolNames(tools); err != nil {
+		t.Errorf("unexpected error for unique tools: %v", err)
+	}
+}
+
+// TestValidateToolNames_Duplicate verifies that two tools sharing the same
+// name via WithRunnerTools return an error containing "duplicate tool name".
+func TestValidateToolNames_Duplicate(t *testing.T) {
+	tools := []goai.Tool{
+		makeTool("read_file", "read a file", "content"),
+		makeTool("read_file", "another read_file", "content2"),
+	}
+	err := validateToolNames(tools)
+	if err == nil {
+		t.Fatal("expected error for duplicate tool name, got nil")
+	}
+	if !strings.Contains(err.Error(), "duplicate tool name") {
+		t.Errorf("error %q does not contain 'duplicate tool name'", err.Error())
+	}
+	if !strings.Contains(err.Error(), "read_file") {
+		t.Errorf("error %q does not mention the duplicate name 'read_file'", err.Error())
+	}
+}
+
+// TestValidateToolNames_Empty verifies that an empty tool slice passes validation.
+func TestValidateToolNames_Empty(t *testing.T) {
+	if err := validateToolNames(nil); err != nil {
+		t.Errorf("unexpected error for nil tools: %v", err)
+	}
+	if err := validateToolNames([]goai.Tool{}); err != nil {
+		t.Errorf("unexpected error for empty tools: %v", err)
+	}
+}
+
+// TestAgentRunner_Run_DuplicateToolNames verifies that AgentRunner.Run returns
+// an error containing "duplicate tool name" when two tools with the same name
+// are supplied via WithRunnerTools.
+func TestAgentRunner_Run_DuplicateToolNames(t *testing.T) {
+	model := &mockModel{
+		responses: []*provider.GenerateResult{
+			textResult("should not reach", 10, 5),
+		},
+	}
+	dupTools := []goai.Tool{
+		makeTool("my_tool", "first instance", "result-a"),
+		makeTool("my_tool", "second instance", "result-b"),
+	}
+	runner := &AgentRunner{model: model}
+	_, err := runner.Run(t.Context(), AgentConfig{}, "do something", "gpt-4o", dupTools)
+	if err == nil {
+		t.Fatal("expected error for duplicate tool names, got nil")
+	}
+	if !strings.Contains(err.Error(), "duplicate tool name") {
+		t.Errorf("error %q does not contain 'duplicate tool name'", err.Error())
+	}
+}


### PR DESCRIPTION
## Problem

In `internal/exec/agent_runner.go`, tools are assembled from multiple sources: user-supplied tools (`WithRunnerTools`), auto-injected framework tools (`send_message`, `submit_result`, `forward_to_agent`), and potentially plugin-loaded tools. There is no uniqueness check — if two tools share the same name, the last one silently wins when passed to goai. This makes bugs extremely hard to trace.

## Fix

Added `validateToolNames` in `internal/exec/tools_validate.go`:

```go
func validateToolNames(tools []goai.Tool) error {
    seen := make(map[string]struct{}, len(tools))
    for _, t := range tools {
        if _, exists := seen[t.Name]; exists {
            return fmt.Errorf("zenflow: duplicate tool name %q: tool names must be unique", t.Name)
        }
        seen[t.Name] = struct{}{}
    }
    return nil
}
```

Called in `AgentRunner.Run` after all tool assembly (user tools + send_message + submit_result injections), before passing to goai. Also added a pre-existence guard on `submit_result` injection (mirrors the existing `send_message` guard) to prevent false positives.

## Tests

Added `TestValidateToolNames_NoDuplicates`, `TestValidateToolNames_Duplicate`, `TestValidateToolNames_Empty`, and `TestAgentRunner_Run_DuplicateToolNames` in `tools_validate_test.go`.

## Related

See also: zendev-sh/goai#<will update> — same fix applied to goai's buildToolMap.