### PR TITLE
feat: add plugin system for external tool loading via .so files

### DIFF
--- a/cmd/zenflow/flags.go
+++ b/cmd/zenflow/flags.go
@@ -32,12 +32,13 @@ type cmdFlags struct {
 	showPlan       bool   // show DAG diagram before execution
 	workdir        string // working directory for LLM tool execution (sandbox)
 	thinking       string // reasoning/thinking level: off|low|medium|high (default off)
+	pluginDir      string // directory to load .so plugins from (default ./plugins/)
 }
 
 // parseFlags parses common CLI flags from args (starting after the positional argument).
 // It returns the parsed flags and an error if an unknown flag or missing value is encountered.
 func parseFlags(args []string) (cmdFlags, error) {
-	f := cmdFlags{maxRetries: -1}
+	f := cmdFlags{maxRetries: -1, pluginDir: "./plugins/"}
 	// First pass: normalise `--key=value` into separate `--key` `value`
 	// tokens and respect a `--` POSIX terminator (everything after `--`
 	// is rejected with a clear message rather than silently consumed).
@@ -164,6 +165,12 @@ func parseFlags(args []string) (cmdFlags, error) {
 			default:
 				return f, fmt.Errorf("invalid --thinking value %q (want off|low|medium|high)", args[i])
 			}
+		case "--plugin-dir":
+			i++
+			if i >= len(args) {
+				return f, fmt.Errorf("--plugin-dir requires a value")
+			}
+			f.pluginDir = args[i]
 		default:
 			if !strings.HasPrefix(args[i], "-") {
 				return f, fmt.Errorf("unexpected positional argument %q (subcommands accept at most one positional; rest must be flags)", args[i])

--- a/cmd/zenflow/main.go
+++ b/cmd/zenflow/main.go
@@ -259,6 +259,7 @@ func usage(w io.Writer) {
 	fmt.Fprintln(w, "  --summary-only      Skip per-step narration, show summary at end (flow/goal only)")
 	fmt.Fprintln(w, "  --resume RUN_ID     Resume from checkpoint (flow only)")
 	fmt.Fprintln(w, "  --workdir DIR       Sandbox directory for tool execution (chdirs here; defaults to cwd)")
+	fmt.Fprintln(w, "  --plugin-dir DIR    Directory to load .so plugin files from (default: ./plugins/)")
 	fmt.Fprintln(w, "  --trace             Enable OTel tracing (binaries shipped via Homebrew/GoReleaser have OTel built in; for `go install` from source, rebuild with -tags otel; default: stderr exporter; honors OTEL_EXPORTER_OTLP_ENDPOINT)")
 	fmt.Fprintln(w, "  --thinking LEVEL    Extended reasoning: off|low|medium|high (default off)")
 	fmt.Fprintln(w, "  --help, -h          Print this help text")

--- a/cmd/zenflow/orchestrator_opts.go
+++ b/cmd/zenflow/orchestrator_opts.go
@@ -89,6 +89,16 @@ func buildOrchestratorOpts(flags cmdFlags) []zenflow.Option {
 	}
 	opts = append(opts, zenflow.WithTools(tool.DefaultToolsIn(workdirAbs)...))
 
+	// Load plugin tools from --plugin-dir (default ./plugins/).
+	if flags.pluginDir != "" {
+		pluginTools, err := tool.LoadPlugins(flags.pluginDir)
+		if err != nil {
+			fmt.Fprintf(stderr, "zenflow: --plugin-dir: %v\n", err)
+		} else if len(pluginTools) > 0 {
+			opts = append(opts, zenflow.WithTools(pluginTools...))
+		}
+	}
+
 	// Max retries: CLI flag overrides YAML options.maxRetries.
 	if flags.maxRetries >= 0 {
 		opts = append(opts, zenflow.WithGoAIOptions(goai.WithMaxRetries(flags.maxRetries)))

--- a/cmd/zenflow/tool/PLUGINS.md
+++ b/cmd/zenflow/tool/PLUGINS.md
@@ -1,0 +1,37 @@
+# zenflow Plugin System
+
+zenflow supports loading external tool plugins compiled as Go shared objects (`.so` files).
+
+## Plugin Contract
+
+A plugin must be a Go package compiled with `-buildmode=plugin` and must export a function with the exact signature:
+
+```go
+func GetTools() ([]goai.Tool, error)
+```
+
+The symbol name must be exactly `GetTools`.
+
+## Build Command
+
+```sh
+go build -buildmode=plugin -o myplugin.so .
+```
+
+See `plugin_example/example.go` for a minimal working plugin.
+
+## Using Plugins with `--plugin-dir`
+
+Place your compiled `.so` files in a directory and pass it to any zenflow subcommand:
+
+```sh
+zenflow agent "do something" --plugin-dir ./my-plugins/
+zenflow flow workflow.yaml --plugin-dir ./my-plugins/
+zenflow goal "achieve something" --plugin-dir ./my-plugins/
+```
+
+The default plugin directory is `./plugins/`. If the directory does not exist, it is silently ignored. If a plugin fails to load or its `GetTools` returns an error, a warning is printed to stderr and that plugin is skipped — other plugins and built-in tools are unaffected.
+
+## Version Compatibility Warning
+
+Plugins must be compiled with the **exact same version of `github.com/zendev-sh/goai`** as the zenflow binary. A mismatch will cause the plugin to fail to load at runtime with a linker error. Always rebuild plugins when upgrading zenflow.

--- a/cmd/zenflow/tool/plugin.go
+++ b/cmd/zenflow/tool/plugin.go
@@ -1,0 +1,60 @@
+package tool
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"plugin"
+
+	"github.com/zendev-sh/goai"
+)
+
+// LoadPlugins loads all .so plugin files from dir and returns their combined
+// tools. If dir does not exist, an empty slice is returned with no error.
+// Plugins that fail to load or return an error from GetTools are skipped with
+// a warning printed to stderr.
+func LoadPlugins(dir string) ([]goai.Tool, error) {
+	if _, err := os.Stat(dir); os.IsNotExist(err) {
+		return nil, nil
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, fmt.Errorf("reading plugin dir %q: %w", dir, err)
+	}
+	var tools []goai.Tool
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".so" {
+			continue
+		}
+		soPath := filepath.Join(dir, entry.Name())
+		plugTools, warn := loadPlugin(soPath)
+		if warn != "" {
+			fmt.Fprintln(os.Stderr, warn)
+			continue
+		}
+		tools = append(tools, plugTools...)
+	}
+	return tools, nil
+}
+
+// loadPlugin opens a single .so file and calls its GetTools symbol.
+// Returns the tools on success or a warning message (non-empty) on failure.
+func loadPlugin(path string) ([]goai.Tool, string) {
+	p, err := plugin.Open(path)
+	if err != nil {
+		return nil, fmt.Sprintf("zenflow: plugin %q: failed to open: %v", path, err)
+	}
+	sym, err := p.Lookup("GetTools")
+	if err != nil {
+		return nil, fmt.Sprintf("zenflow: plugin %q: symbol GetTools not found: %v", path, err)
+	}
+	fn, ok := sym.(func() ([]goai.Tool, error))
+	if !ok {
+		return nil, fmt.Sprintf("zenflow: plugin %q: GetTools has wrong signature (want func() ([]goai.Tool, error))", path)
+	}
+	tools, err := fn()
+	if err != nil {
+		return nil, fmt.Sprintf("zenflow: plugin %q: GetTools returned error: %v", path, err)
+	}
+	return tools, ""
+}

--- a/cmd/zenflow/tool/plugin_example/example.go
+++ b/cmd/zenflow/tool/plugin_example/example.go
@@ -1,0 +1,26 @@
+//go:build ignore
+
+// Package main is an example zenflow plugin that exports a simple "echo" tool.
+// Compile with: go build -buildmode=plugin -o example.so .
+package main
+
+import (
+	"context"
+
+	"github.com/zendev-sh/goai"
+)
+
+// GetTools returns the tools provided by this plugin.
+// This symbol must be exported exactly as `func() ([]goai.Tool, error)`.
+func GetTools() ([]goai.Tool, error) {
+	echoTool := goai.NewTool(
+		"echo",
+		"Returns the input string unchanged. Useful for testing plugin loading.",
+		func(_ context.Context, p struct {
+			Input string `json:"input" jsonschema:"description=The string to echo back"`
+		}) (string, error) {
+			return p.Input, nil
+		},
+	)
+	return []goai.Tool{echoTool}, nil
+}


### PR DESCRIPTION
## Summary

Adds a plugin system that allows external Go shared libraries (`.so` files) to contribute tools to the zenflow agent runtime. Plugins are loaded at startup from a configurable directory and their tools are injected into the tool list alongside built-in tools.

## Changes

- **`cmd/zenflow/tool/plugin.go`** — `LoadPlugins(dir string) ([]goai.Tool, error)`: walks a directory for `.so` files, opens each with the stdlib `plugin` package, looks up the exported `GetTools() ([]goai.Tool, error)` symbol, aggregates results. Missing directory is a no-op. Bad plugins are skipped with a stderr warning.
- **`cmd/zenflow/tool/plugin_example/example.go`** — example plugin (`package main`, `//go:build ignore`) demonstrating the contract with a simple echo tool. Build with `go build -buildmode=plugin -o example.so .`
- **`cmd/zenflow/tool/PLUGINS.md`** — documents the plugin contract, build steps, `--plugin-dir` flag, and goai version compatibility requirement.
- **`cmd/zenflow/flags.go`** — adds `--plugin-dir` flag (default `./plugins/`).
- **`cmd/zenflow/orchestrator_opts.go`** — calls `LoadPlugins` and appends results to the tool slice via `zenflow.WithTools`.
- **`cmd/zenflow/main.go`** — `--plugin-dir` added to usage text.

## Test plan

- [ ] `go build ./...` clean.
- [ ] `go vet ./...` clean.
- [ ] `go test ./... -count=1 -race` PASS.
- [ ] `go tool cover -func=cov.out | grep -v 100.0%` returns no uncovered functions.
- [ ] (If CLI/UX touched) ran a real workflow end-to-end against at least one provider.