### PR TITLE
feat: native MCP server support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 <h1 align="center">zenflow</h1>
 
-<p align="center"><em><a href="https://zenflow.sh/agent-orchestration.html">Multi-agent orchestration & workflow engine.</a></em></p>
+<p align="center"><em><a href="https://zenflow.sh/agent-orchestration.html">The multi-agent harness & workflow engine.</a></em></p>
 
-<p align="center">Declarative YAML agent workflows. An LLM coordinator routes events through hub-and-spoke mailboxes with race-safe delivery. One YAML file, one Go binary. Runs on any provider <a href="https://goai.sh">goai</a> supports.</p>
+<p align="center">A production multi-agent harness. Declarative YAML agent workflows; an LLM coordinator routes events through hub-and-spoke mailboxes with race-safe delivery; agents call native MCP tools. One YAML file, one Go binary. Runs on any provider <a href="https://goai.sh">goai</a> supports.</p>
 
 <p align="center">
   <a href="https://codecov.io/gh/zendev-sh/zenflow"><img src="https://codecov.io/gh/zendev-sh/zenflow/branch/main/graph/badge.svg" alt="Codecov"></a>
@@ -49,6 +49,7 @@ A real `zenflow flow spec/v1/examples/full-featured.yaml --model google/gemini-3
 - **Declarative YAML agent workflows.** Multi-agent workflows expressed in a small composable spec: steps, dependencies, parallel fan-out, conditions (CEL), loops (`forEach`, repeat-until via `untilAgent`/`maxIterations`), and `includes` for sub-workflow reuse.
 - **LLM coordinator with hub-and-spoke messaging.** A coordinator agent narrates progress, forwards events between running steps, and finalizes the run. Peer agents never address each other directly.
 - **Race-safe Mailbox + Wake delivery.** Every message is delivered through a per-agent mailbox with explicit drop reasons. No silent loss, no out-of-order delivery, no leaked goroutines.
+- **Native MCP tools.** Point the harness at a Claude-compatible `.zenflow/settings.json` and every [Model Context Protocol](https://modelcontextprotocol.io) server's tools become available to your agents - stdio, HTTP, or SSE. No Go code, no recompile. Reference a whole server by name in an agent's `tools:`. See [MCP servers](https://zenflow.sh/integrations/mcp).
 - **Multi-provider verified.** Verified against Google `gemini-3-pro-preview`, AWS Bedrock (`anthropic.claude-sonnet-4-6`, `minimax.minimax-m2.5`), and Azure (`DeepSeek-V3.2`, `claude-sonnet-4-6`, `gpt-5`, `gpt-5.3-codex`) - any model [goai](https://goai.sh) supports works.
 - **Spec-first.** Workflows validate against [`spec/v1/schema.json`](https://github.com/zendev-sh/zenflow/blob/main/spec/v1/schema.json) plus a Go validator with 40+ conformance fixtures BEFORE the first LLM call. Cycles, missing dependencies, unknown agents, malformed CEL - all rejected in milliseconds, not after a minute of model burn.
 - **Embed anywhere.** CLI for one-shot runs (`zenflow flow`, `zenflow goal`, `zenflow agent`); Go library primitives (`zenflow.New`, `Orchestrator.RunFlow`) for embedding inside long-running services. Ships as a single static Go binary - no JVM, no Python interpreter, no Node runtime. `go install`, `brew install`, or `curl | sh` and you're running.
@@ -183,6 +184,36 @@ zenflow exposes the same engine through three CLI verbs and one Go library surfa
 
 The library form (`zenflow.New(...).RunFlow(ctx, wf)`) is the same engine; the CLI is a thin wrapper that resolves a provider from `--model`, wires the coordinator, and prints results.
 
+## MCP servers
+
+Give agents tools from any [Model Context Protocol](https://modelcontextprotocol.io) server with a Claude-compatible `.zenflow/settings.json` - no Go code, no recompile:
+
+```json
+{
+  "mcpServers": {
+    "firecrawl": {
+      "command": "npx",
+      "args": ["-y", "firecrawl-mcp"],
+      "env": { "FIRECRAWL_API_KEY": "${FIRECRAWL_API_KEY}" }
+    }
+  }
+}
+```
+
+```yaml
+agents:
+  crawler:
+    description: "Crawls pages with firecrawl."
+    tools: ["read", "write", "firecrawl"]   # bare server name = all its tools
+```
+
+```bash
+zenflow flow crawl.yaml --model google/gemini-2.5-flash --verbose
+# zenflow: MCP loaded 8 tool(s) from server(s) [firecrawl]
+```
+
+The CLI reads `.zenflow/settings.json` by default (override with `--mcp-config`, disable with `--no-mcp`); all three verbs use it. stdio, HTTP, and SSE transports are supported, with `${VAR}` env expansion. Discovered tools are namespaced `<server>__<tool>`. Embedders get the same surface via `LoadMCPConfig` / `ConnectMCPConfig` / `WithAdditionalTools`. Full guide: [MCP servers](https://zenflow.sh/integrations/mcp).
+
 ## Documentation
 
 | Section | What's there |
@@ -192,7 +223,7 @@ The library form (`zenflow.New(...).RunFlow(ctx, wf)`) is the same engine; the C
 | [Concepts](https://zenflow.sh/concepts/) | Agents, scheduling, coordinator, messaging, failure handling, isolation, shared memory, observability, loops, conditions, composition, structured output, tools. |
 | [YAML Reference](https://zenflow.sh/yaml/) | Workflow / agent / step / loop schemas + CEL expression reference. |
 | [CLI Reference](https://zenflow.sh/cli/) | Commands, flags, output formats. |
-| [Integrations](https://zenflow.sh/integrations/) | CI/CD, Docker, scripting, observability (OTel / Langfuse / Jaeger / Datadog). |
+| [Integrations](https://zenflow.sh/integrations/) | MCP servers, CI/CD, Docker, scripting, observability (OTel / Langfuse / Jaeger / Datadog). |
 | [Go API](https://zenflow.sh/api/) | Core functions, options (49 `With*` constructors), types, errors. |
 | [Examples](https://zenflow.sh/examples) | 19 worked examples covering every primitive. |
 | [SKILL.md](SKILL.md) | Top-of-funnel context for AI agents that consume zenflow (tool description, env vars, YAML shape, NDJSON event schema, exit codes, decision flow). Follows the AI-skill format convention; reusable by any agent harness. |

--- a/SKILL.md
+++ b/SKILL.md
@@ -74,6 +74,16 @@ Set the credentials for whichever provider you target:
 
 The `--model` flag accepts the `provider/model-id` form. For Azure, deployment-based URLs are auto-resolved when the model id matches a known deployment family.
 
+## MCP tools
+
+zenflow reads a Claude-compatible `.zenflow/settings.json` and exposes every declared [MCP](https://modelcontextprotocol.io) server's tools to agents. All three verbs use it; override with `--mcp-config PATH`, disable with `--no-mcp`.
+
+```json
+{ "mcpServers": { "firecrawl": { "command": "npx", "args": ["-y", "firecrawl-mcp"], "env": { "FIRECRAWL_API_KEY": "${FIRECRAWL_API_KEY}" } } } }
+```
+
+Tools are namespaced `<server>__<tool>`; an agent's `tools:` list grants a whole server by its bare name (`firecrawl`) or one tool by its full name (`firecrawl__scrape`). stdio, HTTP, and SSE transports are supported, with `${VAR}` env expansion.
+
 ## YAML workflow shape
 
 Minimum:

--- a/cmd/zenflow/cmd_agent.go
+++ b/cmd/zenflow/cmd_agent.go
@@ -17,7 +17,7 @@ import (
 func cmdAgent() {
 	a := osArgs()
 	if len(a) < 3 {
-		fmt.Fprintln(stderr, "usage: zenflow agent <prompt> [--model MODEL] [--max-turns N] [--max-depth N] [--workdir DIR] [--json] [--stream] [--thinking LEVEL] [--verbose] [--yolo] [--sandbox] [--allow LIST] [--deny LIST] [--strict]")
+		fmt.Fprintln(stderr, "usage: zenflow agent <prompt> [--model MODEL] [--max-turns N] [--max-depth N] [--workdir DIR] [--json] [--stream] [--thinking LEVEL] [--mcp-config PATH] [--no-mcp] [--verbose] [--yolo] [--sandbox] [--allow LIST] [--deny LIST] [--strict]")
 		exit(3)
 		return
 	}
@@ -124,6 +124,11 @@ func cmdAgent() {
 	}
 	// Use buildOrchestratorOpts for consistent LLM provider wiring.
 	opts := buildOrchestratorOpts(flags)
+	// Load MCP servers from settings.json and append their tools so the
+	// single agent can call them. Deferred cleanup terminates subprocesses.
+	mcpOpts, mcpCleanup := loadMCPOptions(flags)
+	defer mcpCleanup()
+	opts = append(opts, mcpOpts...)
 	if maxTurns > 0 {
 		opts = append(opts, zenflow.WithMaxTurns(maxTurns))
 	}

--- a/cmd/zenflow/cmd_flow.go
+++ b/cmd/zenflow/cmd_flow.go
@@ -15,7 +15,7 @@ import (
 func cmdFlow() {
 	a := osArgs()
 	if len(a) < 3 {
-		fmt.Fprintln(stderr, "usage: zenflow flow <file> [<context>] [--model MODEL] [--timeout DURATION] [--max-concurrency N] [--max-depth N] [--resume RUN_ID] [--workdir DIR] [--json] [--quiet] [--summary-only] [--stream] [--plan] [--trace] [--thinking LEVEL] [--verbose] [--yolo] [--sandbox] [--allow LIST] [--deny LIST] [--strict]")
+		fmt.Fprintln(stderr, "usage: zenflow flow <file> [<context>] [--model MODEL] [--timeout DURATION] [--max-concurrency N] [--max-depth N] [--resume RUN_ID] [--workdir DIR] [--json] [--quiet] [--summary-only] [--stream] [--plan] [--trace] [--thinking LEVEL] [--mcp-config PATH] [--no-mcp] [--verbose] [--yolo] [--sandbox] [--allow LIST] [--deny LIST] [--strict]")
 		exit(3)
 		return
 	}
@@ -69,6 +69,11 @@ func cmdFlow() {
 	// diagram here too - that double-renders. JSON sink users get the
 	// workflow as a structured event instead.
 	opts := buildOrchestratorOpts(flags)
+	// Load MCP servers from settings.json and append their tools. Deferred
+	// cleanup terminates stdio subprocesses when the run completes.
+	mcpOpts, mcpCleanup := loadMCPOptions(flags)
+	defer mcpCleanup()
+	opts = append(opts, mcpOpts...)
 	// When --model is set, force every per-agent/per-step model resolution
 	// to flags.model. This enables cross-provider CLI testing:
 	// `zenflow flow workflow.yaml --model gemini-2.5-flash` runs all

--- a/cmd/zenflow/cmd_goal.go
+++ b/cmd/zenflow/cmd_goal.go
@@ -16,7 +16,7 @@ import (
 func cmdGoal() {
 	a := osArgs()
 	if len(a) < 3 {
-		fmt.Fprintln(stderr, "usage: zenflow goal <goal> [<extra-context>] [--model MODEL] [--max-concurrency N] [--max-depth N] [--timeout DURATION] [--workdir DIR] [--json] [--quiet] [--summary-only] [--stream] [--trace] [--thinking LEVEL] [--verbose] [--yolo] [--sandbox] [--allow LIST] [--deny LIST] [--strict]")
+		fmt.Fprintln(stderr, "usage: zenflow goal <goal> [<extra-context>] [--model MODEL] [--max-concurrency N] [--max-depth N] [--timeout DURATION] [--workdir DIR] [--json] [--quiet] [--summary-only] [--stream] [--trace] [--thinking LEVEL] [--mcp-config PATH] [--no-mcp] [--verbose] [--yolo] [--sandbox] [--allow LIST] [--deny LIST] [--strict]")
 		exit(3)
 		return
 	}
@@ -70,6 +70,12 @@ func cmdGoal() {
 	stopTracer := installTracerFunc(flags)
 	defer stopTracer()
 	opts := buildOrchestratorOpts(flags)
+	// Load MCP servers from settings.json and append their tools. The
+	// decomposing coordinator can route the generated workflow's steps to
+	// these tools. Deferred cleanup terminates stdio subprocesses.
+	mcpOpts, mcpCleanup := loadMCPOptions(flags)
+	defer mcpCleanup()
+	opts = append(opts, mcpOpts...)
 	// Wire permission handler (interactive TTY prompts or flag-based pre-approval).
 	opts = append(opts, zenflow.WithPermissions(newCliPermissionHandler(perms, osStdin(), stderr, stdinIsTTY())))
 	// coordinator wiring based on flags.

--- a/cmd/zenflow/flags.go
+++ b/cmd/zenflow/flags.go
@@ -32,6 +32,8 @@ type cmdFlags struct {
 	showPlan       bool   // show DAG diagram before execution
 	workdir        string // working directory for LLM tool execution (sandbox)
 	thinking       string // reasoning/thinking level: off|low|medium|high (default off)
+	mcpConfig      string // path to MCP settings.json (default .zenflow/settings.json)
+	noMCP          bool   // disable MCP server loading entirely
 }
 
 // parseFlags parses common CLI flags from args (starting after the positional argument).
@@ -153,6 +155,14 @@ func parseFlags(args []string) (cmdFlags, error) {
 				return f, fmt.Errorf("--workdir requires a value")
 			}
 			f.workdir = args[i]
+		case "--mcp-config":
+			i++
+			if i >= len(args) {
+				return f, fmt.Errorf("--mcp-config requires a path")
+			}
+			f.mcpConfig = args[i]
+		case "--no-mcp":
+			f.noMCP = true
 		case "--thinking":
 			i++
 			if i >= len(args) {

--- a/cmd/zenflow/flags_test.go
+++ b/cmd/zenflow/flags_test.go
@@ -5,6 +5,28 @@ import (
 	"testing"
 )
 
+// TestParseFlags_MCPFlags covers --mcp-config (value) and --no-mcp (bool).
+func TestParseFlags_MCPFlags(t *testing.T) {
+	f, err := parseFlags([]string{"--mcp-config", "custom/settings.json", "--no-mcp"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if f.mcpConfig != "custom/settings.json" {
+		t.Errorf("mcpConfig = %q, want custom/settings.json", f.mcpConfig)
+	}
+	if !f.noMCP {
+		t.Errorf("noMCP = false, want true")
+	}
+}
+
+// TestParseFlags_MCPConfigRequiresValue covers the missing-value branch.
+func TestParseFlags_MCPConfigRequiresValue(t *testing.T) {
+	_, err := parseFlags([]string{"--mcp-config"})
+	if err == nil || !strings.Contains(err.Error(), "--mcp-config requires a path") {
+		t.Fatalf("err = %v, want --mcp-config requires a path", err)
+	}
+}
+
 // TestParseFlags_KeyEqualsValueForm covers the first-pass
 // normaliser that splits `--key=value` into separate tokens.
 func TestParseFlags_KeyEqualsValueForm(t *testing.T) {

--- a/cmd/zenflow/main.go
+++ b/cmd/zenflow/main.go
@@ -261,6 +261,8 @@ func usage(w io.Writer) {
 	fmt.Fprintln(w, "  --workdir DIR       Sandbox directory for tool execution (chdirs here; defaults to cwd)")
 	fmt.Fprintln(w, "  --trace             Enable OTel tracing (binaries shipped via Homebrew/GoReleaser have OTel built in; for `go install` from source, rebuild with -tags otel; default: stderr exporter; honors OTEL_EXPORTER_OTLP_ENDPOINT)")
 	fmt.Fprintln(w, "  --thinking LEVEL    Extended reasoning: off|low|medium|high (default off)")
+	fmt.Fprintln(w, "  --mcp-config PATH   MCP servers settings.json (default .zenflow/settings.json if present)")
+	fmt.Fprintln(w, "  --no-mcp            Disable MCP server loading")
 	fmt.Fprintln(w, "  --help, -h          Print this help text")
 	fmt.Fprintln(w, "  --version, -v       Print zenflow version")
 	fmt.Fprintln(w, "")

--- a/cmd/zenflow/mcp.go
+++ b/cmd/zenflow/mcp.go
@@ -1,0 +1,125 @@
+package main
+
+// mcp.go - CLI glue for native MCP support. zenflow reads a Claude-
+// compatible settings.json (default .zenflow/settings.json), connects to
+// every declared server, and layers the discovered tools onto the
+// orchestrator via WithAdditionalTools. The returned cleanup closes the
+// servers (terminating stdio subprocesses); callers defer it.
+//
+// A present `.zenflow/settings.json` is loaded automatically (like an editor
+// loading project config). It is a trust boundary - a stdio server runs its
+// `command` locally - so only run zenflow in directories you trust; use
+// --no-mcp to skip loading or --mcp-config to point at a file you control.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/zendev-sh/goai"
+	"github.com/zendev-sh/zenflow"
+)
+
+// defaultMCPConfigPath is the conventional location of the MCP settings
+// file, relative to the working directory. Matches the path users reach for
+// by analogy with other agent tools' project config.
+const defaultMCPConfigPath = ".zenflow/settings.json"
+
+// mcpResult is the outcome of resolving + connecting MCP servers.
+type mcpResult struct {
+	tools   []goai.Tool
+	servers []string // connected server names, for logging
+	cleanup func()   // caller MUST defer this
+	active  bool     // true when at least one tool was discovered
+}
+
+// mcpInactive is the "nothing loaded" result with a no-op cleanup.
+var mcpInactive = mcpResult{cleanup: func() {}}
+
+// mcpLoad resolves the MCP config and connects to its servers. It is a seam:
+// tests swap it to exercise loadMCPOptions without real subprocesses.
+var mcpLoad = connectMCPServers
+
+// loadMCPOptions turns the discovered MCP tools into orchestrator option(s)
+// plus a cleanup func the caller MUST defer. When MCP is disabled, absent,
+// or empty it returns no options and a no-op cleanup.
+func loadMCPOptions(flags cmdFlags) ([]zenflow.Option, func()) {
+	r := mcpLoad(flags)
+	if !r.active {
+		return nil, r.cleanup
+	}
+	if flags.verbose {
+		fmt.Fprintf(stderr, "zenflow: MCP loaded %d tool(s) from server(s) %v\n", len(r.tools), r.servers)
+	}
+	return []zenflow.Option{zenflow.WithAdditionalTools(r.tools...)}, r.cleanup
+}
+
+// connectMCPServers is the production implementation of mcpLoad.
+//
+// The connection uses context.Background() deliberately: for stdio servers
+// goai ties the subprocess lifetime to this context, so it must outlive the
+// run. Orderly shutdown happens through the returned cleanup (Toolset.Close),
+// not context cancellation. The connect handshake is bounded by goai's
+// per-request timeout (60s), so a hung server cannot block indefinitely.
+func connectMCPServers(flags cmdFlags) mcpResult {
+	if flags.noMCP {
+		return mcpInactive
+	}
+
+	path := flags.mcpConfig
+	explicit := path != ""
+	if path == "" {
+		path = defaultMCPConfigPath
+	}
+
+	cfg, err := zenflow.LoadMCPConfig(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			// Only complain when the user explicitly pointed us at a path.
+			if explicit {
+				fmt.Fprintf(stderr, "zenflow: MCP config not found: %s\n", path)
+			}
+			return mcpInactive
+		}
+		fmt.Fprintf(stderr, "zenflow: MCP config: %v\n", err)
+		return mcpInactive
+	}
+
+	warnInsecureMCP(cfg)
+
+	mcpOpts := []zenflow.MCPOption{}
+	if flags.verbose {
+		// Surface the subprocess stderr (npx download chatter, server logs)
+		// only in verbose mode to keep normal runs quiet.
+		mcpOpts = append(mcpOpts, zenflow.WithMCPStderr(stderr))
+	}
+
+	ts, err := zenflow.ConnectMCPConfig(context.Background(), cfg, mcpOpts...)
+	if err != nil {
+		// Partial success is possible: report the failures, keep going with
+		// whatever connected.
+		fmt.Fprintf(stderr, "zenflow: MCP: %v\n", err)
+	}
+
+	tools := ts.Tools()
+	if len(tools) == 0 {
+		_ = ts.Close()
+		return mcpInactive
+	}
+	return mcpResult{tools: tools, servers: ts.Servers(), cleanup: func() { _ = ts.Close() }, active: true}
+}
+
+// warnInsecureMCP flags remote servers that would send headers (e.g. a bearer
+// token) over plaintext http://.
+func warnInsecureMCP(cfg *zenflow.MCPConfig) {
+	for name, s := range cfg.MCPServers {
+		if s.Disabled {
+			continue
+		}
+		if strings.HasPrefix(strings.ToLower(strings.TrimSpace(s.URL)), "http://") && len(s.Headers) > 0 {
+			fmt.Fprintf(stderr, "zenflow: warning: MCP server %q sends headers over plaintext http:// (use https://)\n", name)
+		}
+	}
+}

--- a/cmd/zenflow/mcp_test.go
+++ b/cmd/zenflow/mcp_test.go
@@ -1,0 +1,270 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/zendev-sh/goai"
+	"github.com/zendev-sh/goai/mcp"
+	"github.com/zendev-sh/zenflow"
+)
+
+// mcpHTTPServer is a minimal in-process MCP server over Streamable HTTP. It
+// answers goai's connect handshake (GET -> 405 = POST-only), then initialize
+// and tools/list over POST so connectMCPServers can connect for real without
+// a subprocess or the network.
+func mcpHTTPServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			// No server-initiated SSE stream; goai treats 405 as POST-only.
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		var req mcp.JSONRPCMessage
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		if req.ID == nil { // notification (e.g. notifications/initialized)
+			w.WriteHeader(http.StatusAccepted)
+			return
+		}
+		var result any
+		switch req.Method {
+		case "initialize":
+			result = mcp.InitializeResult{
+				ProtocolVersion: mcp.ProtocolVersion20250326,
+				Capabilities:    mcp.ServerCapabilities{Tools: &mcp.ToolsCapability{}},
+				ServerInfo:      mcp.ServerInfo{Name: "everything", Version: "1.0"},
+			}
+		case "tools/list":
+			result = mcp.ListToolsResult{Tools: []mcp.Tool{
+				{Name: "echo", Description: "echo", InputSchema: json.RawMessage(`{"type":"object"}`)},
+			}}
+		default:
+			result = map[string]any{}
+		}
+		raw, _ := json.Marshal(result)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(mcp.JSONRPCMessage{JSONRPC: "2.0", ID: req.ID, Result: raw})
+	}))
+}
+
+// captureStderr redirects the package stderr to a buffer for the test.
+func captureStderr(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	prev := stderr
+	stderr = &buf
+	t.Cleanup(func() { stderr = prev })
+	return &buf
+}
+
+// mcpNamesOf returns the names of a tool slice (for assertions).
+func mcpNamesOf(tools []goai.Tool) []string {
+	n := make([]string, len(tools))
+	for i, x := range tools {
+		n[i] = x.Name
+	}
+	return n
+}
+
+// writeDefaultMCPConfig drops a .zenflow/settings.json into a fresh dir and
+// chdirs there, so connectMCPServers finds it via the default path.
+func writeDefaultMCPConfig(t *testing.T, body string) {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, ".zenflow"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, defaultMCPConfigPath), []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	chdir(t, dir)
+}
+
+// withStubMCPLoad swaps the mcpLoad seam for the duration of a test.
+func withStubMCPLoad(t *testing.T, fn func(cmdFlags) mcpResult) {
+	t.Helper()
+	prev := mcpLoad
+	mcpLoad = fn
+	t.Cleanup(func() { mcpLoad = prev })
+}
+
+func TestLoadMCPOptions_ActiveAppendsTools(t *testing.T) {
+	cleaned := false
+	withStubMCPLoad(t, func(cmdFlags) mcpResult {
+		return mcpResult{
+			tools:   []goai.Tool{{Name: "firecrawl__scrape"}},
+			servers: []string{"firecrawl"},
+			cleanup: func() { cleaned = true },
+			active:  true,
+		}
+	})
+	buf := captureStderr(t)
+
+	opts, cleanup := loadMCPOptions(cmdFlags{verbose: true})
+	if len(opts) != 1 {
+		t.Fatalf("opts = %d, want 1 (WithAdditionalTools)", len(opts))
+	}
+	if !strings.Contains(buf.String(), "MCP loaded 1 tool(s) from server(s) [firecrawl]") {
+		t.Errorf("verbose log missing, got %q", buf.String())
+	}
+	cleanup()
+	if !cleaned {
+		t.Error("cleanup not invoked")
+	}
+}
+
+func TestLoadMCPOptions_InactiveNoOpts(t *testing.T) {
+	withStubMCPLoad(t, func(cmdFlags) mcpResult { return mcpInactive })
+	opts, cleanup := loadMCPOptions(cmdFlags{})
+	if opts != nil {
+		t.Errorf("opts = %v, want nil when inactive", opts)
+	}
+	cleanup() // must be safe
+}
+
+func TestConnectMCPServers_SuccessLoadsTools(t *testing.T) {
+	srv := mcpHTTPServer(t)
+	defer srv.Close()
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "settings.json")
+	body := `{"mcpServers":{"everything":{"url":"` + srv.URL + `"}}}`
+	if err := os.WriteFile(cfgPath, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	buf := captureStderr(t)
+
+	// verbose exercises the stderr subprocess-routing option path too.
+	r := connectMCPServers(cmdFlags{mcpConfig: cfgPath, verbose: true})
+	defer r.cleanup()
+	if !r.active {
+		t.Fatalf("expected active=true; stderr=%q", buf.String())
+	}
+	if len(r.tools) != 1 || r.tools[0].Name != "everything__echo" {
+		t.Fatalf("tools = %v, want [everything__echo]", mcpNamesOf(r.tools))
+	}
+	if len(r.servers) != 1 || r.servers[0] != "everything" {
+		t.Fatalf("servers = %v, want [everything]", r.servers)
+	}
+}
+
+func TestConnectMCPServers_DefaultPathAutoLoads(t *testing.T) {
+	srv := mcpHTTPServer(t)
+	defer srv.Close()
+	// An auto-discovered .zenflow/settings.json loads without any prompt.
+	writeDefaultMCPConfig(t, `{"mcpServers":{"everything":{"url":"`+srv.URL+`"}}}`)
+	captureStderr(t)
+
+	r := connectMCPServers(cmdFlags{})
+	defer r.cleanup()
+	if !r.active || len(r.tools) != 1 {
+		t.Fatalf("expected auto-load from default path, got active=%v tools=%v", r.active, mcpNamesOf(r.tools))
+	}
+}
+
+func TestConnectMCPServers_NoMCPFlag(t *testing.T) {
+	r := connectMCPServers(cmdFlags{noMCP: true})
+	if r.active || r.tools != nil || r.servers != nil {
+		t.Error("expected inactive with --no-mcp")
+	}
+	r.cleanup()
+}
+
+func TestConnectMCPServers_MissingDefaultSilent(t *testing.T) {
+	chdir(t, t.TempDir()) // empty dir => default .zenflow/settings.json absent
+	buf := captureStderr(t)
+
+	r := connectMCPServers(cmdFlags{})
+	if r.active {
+		t.Error("expected inactive when default config absent")
+	}
+	if buf.Len() != 0 {
+		t.Errorf("missing default config should be silent, got %q", buf.String())
+	}
+}
+
+func TestConnectMCPServers_MissingExplicitWarns(t *testing.T) {
+	buf := captureStderr(t)
+	r := connectMCPServers(cmdFlags{mcpConfig: filepath.Join(t.TempDir(), "nope.json")})
+	if r.active {
+		t.Error("expected inactive")
+	}
+	if !strings.Contains(buf.String(), "MCP config not found") {
+		t.Errorf("expected not-found warning, got %q", buf.String())
+	}
+}
+
+func TestConnectMCPServers_MalformedWarns(t *testing.T) {
+	dir := t.TempDir()
+	bad := filepath.Join(dir, "settings.json")
+	if err := os.WriteFile(bad, []byte("{not json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	buf := captureStderr(t)
+	r := connectMCPServers(cmdFlags{mcpConfig: bad})
+	if r.active {
+		t.Error("expected inactive on malformed config")
+	}
+	if !strings.Contains(buf.String(), "MCP config:") {
+		t.Errorf("expected parse warning, got %q", buf.String())
+	}
+}
+
+func TestConnectMCPServers_ConnectFailureNoTools(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "settings.json")
+	// A server whose command does not exist: connection fails, no tools.
+	body := `{"mcpServers":{"ghost":{"command":"zenflow-no-such-mcp-binary-xyz"}}}`
+	if err := os.WriteFile(cfgPath, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	buf := captureStderr(t)
+	r := connectMCPServers(cmdFlags{mcpConfig: cfgPath, verbose: true})
+	if r.active || len(r.tools) != 0 {
+		t.Error("expected inactive with no tools when the server fails to start")
+	}
+	if !strings.Contains(buf.String(), "zenflow: MCP:") {
+		t.Errorf("expected connect-failure warning, got %q", buf.String())
+	}
+	r.cleanup()
+}
+
+func TestWarnInsecureMCP(t *testing.T) {
+	buf := captureStderr(t)
+	warnInsecureMCP(&zenflow.MCPConfig{MCPServers: map[string]zenflow.MCPServerConfig{
+		"plain":    {URL: "http://x/mcp", Headers: map[string]string{"Authorization": "Bearer t"}},
+		"secure":   {URL: "https://x/mcp", Headers: map[string]string{"Authorization": "Bearer t"}},
+		"noheader": {URL: "http://x/mcp"},
+		"off":      {URL: "http://x/mcp", Headers: map[string]string{"A": "b"}, Disabled: true},
+	}})
+	out := buf.String()
+	if !strings.Contains(out, `"plain"`) {
+		t.Errorf("expected warning for plaintext+headers server, got %q", out)
+	}
+	if strings.Contains(out, `"secure"`) || strings.Contains(out, `"noheader"`) || strings.Contains(out, `"off"`) {
+		t.Errorf("unexpected warning, got %q", out)
+	}
+}
+
+// chdir changes to dir for the duration of the test, restoring the prior cwd.
+func chdir(t *testing.T, dir string) {
+	t.Helper()
+	prev, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(prev) })
+}

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -266,6 +266,7 @@ export default defineConfig({
           collapsed: false,
           items: [
             { text: 'Overview', link: '/integrations/' },
+            { text: 'MCP Servers', link: '/integrations/mcp' },
             { text: 'CI/CD', link: '/integrations/ci-cd' },
             { text: 'Docker', link: '/integrations/docker' },
             { text: 'Scripting', link: '/integrations/scripting' },

--- a/docs/api/options.md
+++ b/docs/api/options.md
@@ -113,6 +113,57 @@ orch := zenflow.New(
 
 For per-call tool restriction (e.g., a sub-agent gets only read-only tools), set `AgentConfig.CallTools` instead of using a separate orchestrator.
 
+### `WithAdditionalTools`
+
+```go
+func WithAdditionalTools(tools ...goai.Tool) Option
+```
+
+Appends tools to the catalog instead of replacing it. `WithTools` overwrites the whole slice; `WithAdditionalTools` layers onto whatever an earlier `WithTools` installed. This is the canonical way to add [MCP](/integrations/mcp)-discovered tools on top of a built-in set without rebuilding the slice.
+
+```go
+orch := zenflow.New(
+    zenflow.WithModel(model),
+    zenflow.WithTools(builtins...),          // base catalog
+    zenflow.WithAdditionalTools(mcpTools...), // layered on top
+)
+```
+
+### MCP configuration
+
+zenflow loads [Model Context Protocol](https://modelcontextprotocol.io) servers from a Claude-compatible `settings.json` and exposes their tools as ordinary `goai.Tool` values.
+
+```go
+func LoadMCPConfig(path string) (*MCPConfig, error)
+func ConnectMCPConfig(ctx context.Context, cfg *MCPConfig, opts ...MCPOption) (*MCPToolset, error)
+
+func WithMCPClientInfo(name, version string) MCPOption
+func WithMCPRequestTimeout(d time.Duration) MCPOption
+func WithMCPStderr(w io.Writer) MCPOption
+```
+
+`LoadMCPConfig` parses the file (a missing file returns an error satisfying `errors.Is(err, os.ErrNotExist)`). `ConnectMCPConfig` connects to every enabled server and returns an `*MCPToolset`; `ts.Tools()` feeds `WithAdditionalTools`, and `ts.Close()` shuts the servers down. A failure connecting to one server does not abort the rest - the toolset carries every server that connected and the error joins the failures.
+
+```go
+cfg, err := zenflow.LoadMCPConfig(".zenflow/settings.json")
+if err != nil && !errors.Is(err, os.ErrNotExist) {
+    return err
+}
+ts, err := zenflow.ConnectMCPConfig(ctx, cfg)
+if err != nil {
+    log.Printf("partial MCP load: %v", err)
+}
+defer ts.Close()
+
+orch := zenflow.New(
+    zenflow.WithModel(model),
+    zenflow.WithTools(builtins...),
+    zenflow.WithAdditionalTools(ts.Tools()...),
+)
+```
+
+See the [MCP servers guide](/integrations/mcp) for the `settings.json` format, transports, env expansion, and tool grouping.
+
 ### `WithMaxTurns`
 
 ```go

--- a/docs/cli/flags.md
+++ b/docs/cli/flags.md
@@ -17,6 +17,13 @@ The `Applies to` column lists the verbs that recognize the flag. Flags not liste
 | `--max-retries N` | integer | provider default | flow, goal, agent | Per-step cap on the agent runner's tool-call retry budget (passed via `goai.WithMaxRetries`). Distinct from `step.retries`, which retries the whole step on failure. When unset, [goai](https://goai.sh)'s built-in retry policy applies. `N >= 0`. `N = 0` disables retries. |
 | `--thinking LEVEL` | enum | `off` | flow, goal, agent | Extended reasoning. Valid values: `off`, `low`, `medium`, `high`. Routed to provider-native keys (Bedrock `reasoningConfig`, Anthropic `thinking`, Google `thinkingConfig`, OpenAI/Azure `reasoning_effort`). Each provider reads only what it understands. |
 
+## MCP servers
+
+| Flag | Type | Default | Applies to | Description |
+| --- | --- | --- | --- | --- |
+| `--mcp-config PATH` | path | `.zenflow/settings.json` | flow, goal, agent | Read [MCP](/integrations/mcp) servers from a Claude-compatible `settings.json` at `PATH`. When unset, the default path is loaded if present (a missing default is a silent no-op; a missing explicit `PATH` is reported). Discovered tools are namespaced `<server>__<tool>` and grantable by bare server name in an agent's `tools:`. The file launches local commands - it is a [trust boundary](/integrations/mcp#security). |
+| `--no-mcp` | bool | off | flow, goal, agent | Skip MCP server loading entirely, even if a config file is present. |
+
 ## Lifecycle and execution
 
 | Flag | Type | Default | Applies to | Description |

--- a/docs/concepts/tools.md
+++ b/docs/concepts/tools.md
@@ -7,11 +7,12 @@ description: Agents in zenflow do work through tools. A tool is a function the L
 
 Agents in zenflow do work through tools. A tool is a function the LLM can call - bash command, file read, HTTP request, anything. Tools turn an LLM from a chat surface into something that touches the world.
 
-Zenflow distinguishes three kinds of tools:
+Zenflow distinguishes four kinds of tools:
 
 1. **Built-in CLI tools** (`bash`, `read`, `write`, `glob`, `grep`) - shipped with the `zenflow` binary, available to YAML-declared agents in CLI runs.
 2. **Library-supplied tools** - any `goai.Tool` you register via `WithTools`. The CLI is a consumer of this surface; embedded users supply their own.
-3. **Auto-injected tools** - the executor adds `send_message`, `shared_memory_read`, `shared_memory_write`, `submit_result` automatically when the workflow uses messaging, shared memory, or structured output.
+3. **MCP tools** - tools discovered from [Model Context Protocol](https://modelcontextprotocol.io) servers declared in `settings.json`. zenflow connects and exposes them natively - no Go code. See [MCP servers](/integrations/mcp).
+4. **Auto-injected tools** - the executor adds `send_message`, `shared_memory_read`, `shared_memory_write`, `submit_result` automatically when the workflow uses messaging, shared memory, or structured output.
 
 ## Built-in CLI tools
 
@@ -78,8 +79,9 @@ Each agent's effective tool set is `(allowlist) - (denylist)`:
 - Omit `tools` - every registered tool is available to the agent.
 - `tools: [a, b]` - only `a` and `b`.
 - `disallowedTools: [bash]` - removed from the resolved allowlist.
+- `tools: [firecrawl]` - an MCP **server name** grants every tool that server contributed (`firecrawl__scrape`, `firecrawl__crawl`, ...). Works in both lists. See [MCP servers](/integrations/mcp).
 
-The executor resolves the names against the orchestrator's tool catalogue (the slice you passed to `WithTools`). Names that do not match any registered tool surface as a load-time error.
+The executor resolves the names against the orchestrator's tool catalogue (the slice you passed to `WithTools` / `WithAdditionalTools`). Names that do not match any registered tool - or MCP server group - surface as a load-time error before the first LLM call.
 
 ## Auto-injected tools
 
@@ -126,32 +128,47 @@ Use cases:
 
 The handler runs synchronously in the agent's loop. Keep it fast - a slow handler stalls the LLM.
 
-## MCP tools via goai
+## MCP tools (native)
 
-[Model Context Protocol](https://modelcontextprotocol.io) servers expose tool catalogues over a standard wire format. Goai includes an MCP client that converts MCP tools into `goai.Tool` values. They register with `WithTools` like any other tool:
+[Model Context Protocol](https://modelcontextprotocol.io) servers expose tool catalogues over a standard wire format. zenflow supports MCP natively: point it at a Claude-compatible `settings.json` and every server's tools become available to your agents - no Go code, no recompile.
+
+```json
+// .zenflow/settings.json
+{
+  "mcpServers": {
+    "firecrawl": {
+      "command": "npx",
+      "args": ["-y", "firecrawl-mcp"],
+      "env": { "FIRECRAWL_API_KEY": "${FIRECRAWL_API_KEY}" }
+    }
+  }
+}
+```
+
+```yaml
+agents:
+  crawler:
+    description: "Crawls pages with firecrawl."
+    tools: ["read", "write", "firecrawl"]   # bare server name = all its tools
+```
+
+The CLI reads `.zenflow/settings.json` automatically (override with `--mcp-config`, disable with `--no-mcp`). Discovered tools are namespaced `<server>__<tool>`; an agent can grant a whole server by its bare name or a single tool by its full name.
+
+Embedders get the same surface as a small library API - `LoadMCPConfig`, `ConnectMCPConfig`, and `WithAdditionalTools` (which appends to the catalog rather than replacing it):
 
 ```go
-import "github.com/zendev-sh/goai/mcp"
-
-client := mcp.NewClient("zenflow", "1.0.0")
-if err := client.Connect(ctx); err != nil {
-    return err
-}
-defer client.Close()
-
-result, err := client.ListTools(ctx, nil)
-if err != nil {
-    return err
-}
-mcpTools := mcp.ConvertTools(client, result.Tools)
+cfg, _ := zenflow.LoadMCPConfig(".zenflow/settings.json")
+ts, _ := zenflow.ConnectMCPConfig(ctx, cfg)
+defer ts.Close()
 
 orch := zenflow.New(
     zenflow.WithModel(llm),
-    zenflow.WithTools(mcpTools...),
+    zenflow.WithTools(builtins...),
+    zenflow.WithAdditionalTools(ts.Tools()...),
 )
 ```
 
-The agent calls them by their MCP-declared names. Zenflow does not need to know they came from MCP - they look like any other `goai.Tool`. See [goai MCP docs](https://goai.sh) for full setup and authentication options.
+zenflow does not need to know a tool came from MCP - it looks like any other `goai.Tool`. See the [MCP servers guide](/integrations/mcp) for the full config format (stdio / HTTP / SSE), env expansion, grouping, and lifecycle.
 
 ## Tool execution and side effects
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,13 +1,13 @@
 ---
 layout: home
-title: zenflow - multi-agent orchestration engine
-titleTemplate: Multi-agent orchestration & workflow engine for Go
-description: Multi-agent orchestration engine for Go. Declarative YAML agent workflows with an LLM coordinator, hub-and-spoke messaging, race-safe delivery, and spec-first validation. Single static binary, no runtime.
+title: zenflow - the multi-agent harness
+titleTemplate: Multi-agent orchestration harness & workflow engine for Go
+description: zenflow is a production multi-agent harness for Go. Declarative YAML agent workflows with an LLM coordinator, hub-and-spoke messaging, race-safe delivery, native MCP tools, and spec-first validation. Single static binary, no runtime.
 
 hero:
   name: zenflow
-  text: Let agents flow.
-  tagline: A <a href="/agent-orchestration.html" class="zf-hero-link">multi-agent orchestration</a> engine that turns declarative YAML agent workflows into a running plan. An LLM coordinator routes events through hub-and-spoke mailboxes with race-safe delivery. Runs on any provider goai supports.
+  text: The multi-agent harness.
+  tagline: A <a href="/agent-orchestration.html" class="zf-hero-link">multi-agent orchestration</a> harness that turns declarative YAML agent workflows into a running plan. An LLM coordinator routes events through hub-and-spoke mailboxes with race-safe delivery, agents call native MCP tools, and the whole harness ships as one static binary. Runs on any provider goai supports.
   image:
     light: /zenflow-icon.png
     dark: /zenflow-icon-dark.png
@@ -24,8 +24,8 @@ hero:
       link: https://github.com/zendev-sh/zenflow
 
 features:
-  - title: Declarative YAML agent workflows
-    details: Multi-agent workflows expressed in a small composable spec. Steps, dependencies, parallel fan-out, conditions (CEL), loops, and includes for sub-workflow reuse. The plan ships in a YAML file you can review in a PR.
+  - title: Declarative, spec-first YAML
+    details: Multi-agent workflows in a small composable spec - steps, dependencies, parallel fan-out, conditions (CEL), loops, includes. Every plan ships in a reviewable YAML file and validates against spec/v1/schema.json plus 40+ Go conformance fixtures BEFORE the first LLM call. Cycles, missing deps, unknown agents, malformed CEL - rejected in milliseconds, not after a minute of model burn.
     link: /yaml/
     linkText: YAML reference
   - title: LLM coordinator with hub-and-spoke messaging
@@ -36,16 +36,16 @@ features:
     details: Every message is delivered through a per-agent mailbox with explicit drop reasons. No silent loss, no out-of-order delivery, no leaked goroutines.
     link: /concepts/messaging
     linkText: Messaging model
+  - title: Native MCP tools
+    details: Point the harness at a Claude-compatible settings.json and every Model Context Protocol server's tools become available to your agents - stdio, HTTP, or SSE. No Go code, no recompile. Grant a whole server to an agent by name.
+    link: /integrations/mcp
+    linkText: MCP servers
   - title: Multi-provider verified
     details: Verified against Google gemini-3-pro-preview, AWS Bedrock (claude-sonnet-4-6, minimax-m2.5), and Azure (DeepSeek-V3.2, claude-sonnet-4-6, gpt-5, gpt-5.3-codex). Any model goai supports works.
     link: /concepts/agents
     linkText: How agents work
-  - title: Spec-first
-    details: Workflows validate against spec/v1/schema.json plus a Go validator with 40+ conformance fixtures BEFORE the first LLM call. Cycles, missing dependencies, unknown agents, malformed CEL - all rejected in milliseconds, not after a minute of model burn.
-    link: /yaml/
-    linkText: YAML reference
-  - title: Embed anywhere
-    details: CLI for one-shot runs (zenflow flow, zenflow goal, zenflow agent), or a small Go library surface (zenflow.New, Orchestrator.RunFlow) for embedding inside long-running services. Ships as a single static Go binary - no JVM, no Python interpreter, no Node runtime.
+  - title: Embed the harness anywhere
+    details: CLI for one-shot runs (zenflow flow, zenflow goal, zenflow agent), or a small Go library surface (zenflow.New, Orchestrator.RunFlow) for embedding the harness inside long-running services. Ships as a single static Go binary - no JVM, no Python interpreter, no Node runtime.
     link: /integrations/
     linkText: Integrations
 ---
@@ -65,9 +65,9 @@ A real `zenflow flow spec/v1/examples/full-featured.yaml --model google/gemini-3
 
 ## Why zenflow
 
-zenflow makes two opinionated choices. The workflow is a YAML file you can review in a PR: versionable, diffable, runnable from any language that can shell out to a binary. And every inter-agent message is either delivered to a mailbox or dropped with a typed reason. There is no third option.
+zenflow is an agent harness with two opinionated choices. The workflow is a YAML file you can review in a PR: versionable, diffable, runnable from any language that can shell out to a binary. And every inter-agent message is either delivered to a mailbox or dropped with a typed reason. There is no third option.
 
-zenflow is built for production embedders: systems that run workflows from a queue, persist state to a database, and need an audit trail when something goes sideways. The whole engine is one Go module with a small, stable Orchestrator API.
+The harness is built for production embedders: systems that run workflows from a queue, persist state to a database, and need an audit trail when something goes sideways. Agents reach the outside world through tools - the built-in `read` / `write` / `bash` set, anything you register in Go, and any [MCP server](/integrations/mcp) you declare in a `settings.json`. The whole harness is one Go module with a small, stable Orchestrator API.
 
 ## Three modes, one engine
 

--- a/docs/integrations/index.md
+++ b/docs/integrations/index.md
@@ -15,6 +15,7 @@ Pick the surface that matches what you already do:
 
 | You want to... | Reach for | Notes |
 | --- | --- | --- |
+| Give agents tools from an MCP server | [MCP servers](./mcp) | Claude-compatible `settings.json`; stdio / HTTP / SSE. No Go code, no recompile. |
 | Run a workflow on every push or PR | [CI/CD](./ci-cd) | GitHub Actions, GitLab CI, CircleCI examples. The binary is small, no daemon. |
 | Bake zenflow into an image you deploy | [Docker](./docker) | Multi-stage `golang:1.25` build, distroless runtime, Kubernetes Job manifest. |
 | Drive zenflow from a shell, Node, or Python script | [Scripting](./scripting) | NDJSON event stream via `--json`, exit-code semantics, parsing patterns. |

--- a/docs/integrations/mcp.md
+++ b/docs/integrations/mcp.md
@@ -1,0 +1,298 @@
+---
+title: MCP servers
+description: zenflow speaks the Model Context Protocol natively. Point it at a Claude-compatible settings.json and every MCP server's tools become available to your agents - no Go code, no recompile.
+---
+
+# MCP servers
+
+zenflow is an MCP-native agent harness. [Model Context Protocol](https://modelcontextprotocol.io) servers expose tools (and prompts and resources) over a standard wire format; zenflow connects to them, discovers their tools, and hands those tools to your agents exactly like the built-in `read` / `write` / `bash` set. The wire protocol is owned by [goai](https://goai.sh)'s MCP client - zenflow is the glue that turns a config file into a running, tool-equipped workflow.
+
+You configure MCP servers in a Claude-compatible `settings.json`. No Go code, no recompile.
+
+## Quick start (CLI)
+
+Drop a `.zenflow/settings.json` next to where you run the CLI:
+
+```json
+{
+  "mcpServers": {
+    "firecrawl": {
+      "command": "npx",
+      "args": ["-y", "firecrawl-mcp"],
+      "env": {
+        "FIRECRAWL_API_KEY": "${FIRECRAWL_API_KEY}"
+      }
+    }
+  }
+}
+```
+
+Reference the server in an agent's `tools:` list - the bare server name grants **all** of that server's tools:
+
+```yaml
+name: summarize
+agents:
+  crawler:
+    description: "Crawls pages with the firecrawl MCP server."
+    tools: ["read", "write", "firecrawl"]   # 'firecrawl' = every firecrawl tool
+  writer:
+    description: "Reads and summarizes."
+    tools: ["read", "write"]
+
+steps:
+  - id: crawl
+    agent: crawler
+    instructions: "Crawl https://www.wikipedia.org/ as markdown using the firecrawl tools, then write it to download.md"
+  - id: write
+    agent: writer
+    instructions: "Read download.md and write a summary to summary.md"
+    dependsOn: ["crawl"]
+```
+
+```bash
+export FIRECRAWL_API_KEY=fc-...
+zenflow flow summarize.yaml --model google/gemini-2.5-flash --verbose
+```
+
+With `--verbose`, zenflow prints what it loaded:
+
+```
+zenflow: MCP loaded 8 tool(s) from server(s) [firecrawl]
+```
+
+The same config is read by all three CLI verbs - `zenflow flow`, `zenflow goal`, and `zenflow agent`.
+
+## Config file
+
+By default zenflow looks for `.zenflow/settings.json` relative to the working directory. Override or disable it:
+
+| Flag | Effect |
+| --- | --- |
+| `--mcp-config PATH` | Read MCP servers from `PATH` instead of the default. |
+| `--no-mcp` | Skip MCP loading entirely. |
+
+A missing default file is a silent no-op - MCP is opt-in by the presence of the file. An explicit `--mcp-config PATH` that does not exist is reported.
+
+### Server entry shapes
+
+Each entry under `mcpServers` is one server. The transport is inferred from the fields, or set explicitly with `"type"`.
+
+**Stdio (local subprocess)** - the common case:
+
+```json
+{
+  "mcpServers": {
+    "filesystem": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-filesystem", "/data"],
+      "env": { "LOG_LEVEL": "info" }
+    }
+  }
+}
+```
+
+**Remote (Streamable HTTP or SSE)**:
+
+```json
+{
+  "mcpServers": {
+    "remote-http": {
+      "url": "https://mcp.example.com/v1",
+      "headers": { "Authorization": "Bearer ${MCP_TOKEN}" }
+    },
+    "legacy-sse": {
+      "type": "sse",
+      "url": "https://sse.example.com/mcp"
+    }
+  }
+}
+```
+
+| Field | Applies to | Meaning |
+| --- | --- | --- |
+| `command`, `args` | stdio | Executable and arguments for the subprocess. |
+| `env` | stdio | Extra environment variables (merged onto the parent env). |
+| `url` | http / sse | Remote server endpoint. |
+| `headers` | http / sse | Headers sent on every request (auth, etc.). |
+| `type` | all | `"stdio"`, `"http"`, or `"sse"`. Empty infers: `command` → stdio, `url` → http. |
+| `disabled` | all | `true` skips this server. |
+
+**Environment expansion.** Every string in `command`, `args`, `env`, `url`, and `headers` is expanded with `${VAR}` / `$VAR` from the process environment, so secrets stay out of the file:
+
+```json
+{ "env": { "FIRECRAWL_API_KEY": "${FIRECRAWL_API_KEY}" } }
+```
+
+## Remote servers (HTTP / SSE)
+
+A remote server is one you reach over the network instead of spawning locally. Set `url` (the transport defaults to Streamable HTTP) and pass auth via `headers`. zenflow connects exactly the same way - the tools come back namespaced and grantable by server name.
+
+### Example: GitHub's remote MCP server
+
+GitHub hosts an official remote MCP server at `https://api.githubcopilot.com/mcp/`. Authenticate with a token in an `Authorization` header (keep the token in an env var, not the file):
+
+```json
+// .zenflow/settings.json
+{
+  "mcpServers": {
+    "github": {
+      "type": "http",
+      "url": "https://api.githubcopilot.com/mcp/",
+      "headers": { "Authorization": "Bearer ${GITHUB_MCP_TOKEN}" }
+    }
+  }
+}
+```
+
+```yaml
+# review.yaml
+name: triage
+agents:
+  dev:
+    description: "GitHub assistant."
+    tools: ["github"]   # bare server name = every github__* tool
+steps:
+  - id: triage
+    agent: dev
+    instructions: "Use the github tools to find the 5 oldest open issues in zendev-sh/zenflow and summarize each."
+```
+
+```bash
+export GITHUB_MCP_TOKEN=$(gh auth token)   # or a fine-grained PAT
+zenflow flow review.yaml --model google/gemini-2.5-flash --verbose --yolo
+# zenflow: MCP loaded 44 tool(s) from server(s) [github]
+```
+
+The server exposes ~44 tools (`github__search_repositories`, `github__get_file_contents`, `github__list_issues`, `github__create_pull_request`, ...). The `tools: ["github"]` group above grants **all** of them, including write-capable ones.
+
+For a run that can only read, prefer an explicit allowlist over a partial `disallowedTools` - the group includes more write tools than you might remember (`issue_write`, `merge_pull_request`, `push_files`, ...), so listing just the read tools is safer:
+
+```yaml
+agents:
+  reader:
+    description: "Read-only GitHub researcher."
+    tools:
+      - github__search_repositories
+      - github__get_file_contents
+      - github__list_issues
+      - github__issue_read
+      - github__list_releases
+      - github__get_latest_release
+```
+
+### SSE transport
+
+For older servers that speak the legacy SSE protocol, set `"type": "sse"`:
+
+```json
+{ "mcpServers": { "legacy": { "type": "sse", "url": "https://sse.example.com/mcp" } } }
+```
+
+### Troubleshooting: `HTTP 400` on connect
+
+```
+zenflow: MCP: mcp server "github": mcp: transport start: mcp: SSE connection failed: HTTP 400
+✗ zenflow: validation: agent "reader" references unknown tool "github__search_repositories"
+```
+
+The first line is the real cause; the second is a knock-on (no tools loaded, so the allowlist references nothing). The usual culprits:
+
+- **Empty or invalid auth token (most common).** If `${GITHUB_MCP_TOKEN}` resolves to an empty string - the env var was never exported - the header becomes `Authorization: Bearer ` and GitHub rejects it with `400`. Export the token first: `export GITHUB_MCP_TOKEN=$(gh auth token)`, and double-check it is non-empty.
+- **Server doesn't support the SSE-GET probe.** zenflow's Streamable HTTP transport opens an optional server-initiated SSE stream on connect, tolerating `405`/`404` (POST-only servers). A server that answers that probe with `400` instead - some non-GitHub implementations - is not spec-compliant for that handshake; use `"type": "sse"` against its SSE endpoint, or run it locally over stdio.
+
+## Tool naming and grouping
+
+Discovered tools are namespaced `<server>__<tool>` so two servers can never collide. A firecrawl server that exposes `scrape` and `crawl` contributes `firecrawl__scrape` and `firecrawl__crawl`.
+
+In an agent's `tools:` allowlist (or `disallowedTools:`) you can reference either:
+
+- the **bare server name** - `firecrawl` selects every `firecrawl__*` tool, or
+- a **specific tool** - `firecrawl__scrape` selects just that one.
+
+Built-in tool names (`read`, `write`, `bash`, `glob`, `grep`) contain no `__` separator, so grouping never affects them.
+
+If an agent references a tool that no server provided (a typo, or a server that failed to load), zenflow rejects the workflow before the first LLM call with a clear `references unknown tool` error - it does not silently drop the tool.
+
+## Embedding in Go
+
+The CLI path is a thin consumer of a small library surface. Load the config, connect, and layer the tools onto the orchestrator with `WithAdditionalTools`:
+
+```go
+package main
+
+import (
+    "context"
+    "errors"
+    "log"
+    "os"
+
+    "github.com/zendev-sh/goai/provider/google"
+    "github.com/zendev-sh/zenflow"
+)
+
+func main() {
+    ctx := context.Background()
+
+    cfg, err := zenflow.LoadMCPConfig(".zenflow/settings.json")
+    if errors.Is(err, os.ErrNotExist) {
+        cfg = &zenflow.MCPConfig{} // no MCP configured; carry on
+    } else if err != nil {
+        log.Fatal(err)
+    }
+
+    // Connect to every server. ctx governs stdio subprocess lifetime, so it
+    // must outlive tool use; orderly shutdown is ts.Close().
+    ts, err := zenflow.ConnectMCPConfig(ctx, cfg)
+    if err != nil {
+        log.Printf("some MCP servers failed: %v", err) // partial success is OK
+    }
+    defer ts.Close()
+
+    llm := google.Chat("gemini-2.5-flash", google.WithAPIKey(os.Getenv("GEMINI_API_KEY")))
+    orch := zenflow.New(
+        zenflow.WithModel(llm),
+        zenflow.WithTools(/* your built-in tools */),
+        zenflow.WithAdditionalTools(ts.Tools()...), // appends; does not replace
+        zenflow.WithCoordinator(zenflow.NewDefaultCoordRunner(llm)),
+    )
+    defer orch.Close()
+
+    // orch.RunFlow(ctx, wf) ...
+}
+```
+
+Key points:
+
+- **`WithAdditionalTools` appends.** `WithTools` *replaces* the catalog; `WithAdditionalTools` layers onto it. Use the latter for MCP so you keep your built-ins.
+- **`ConnectMCPConfig` is resilient.** One unreachable server does not abort the rest - the returned `*MCPToolset` carries every server that connected, and the error is the join of the failures. Use the toolset even on a non-nil error, and always `Close` it.
+- **`ctx` governs stdio lifetime.** goai starts stdio servers with the context you pass; hand it one that lives as long as the tools may be called, and rely on `MCPToolset.Close()` for shutdown rather than cancelling that context.
+
+### Connection options
+
+| Option | Effect |
+| --- | --- |
+| `WithMCPClientInfo(name, version)` | Identity advertised to servers in the initialize handshake (default `zenflow`/`1.0.0`). |
+| `WithMCPRequestTimeout(d)` | Bounds each MCP request, including the connect handshake and every tool call (default 60s). |
+| `WithMCPStderr(w)` | Routes stdio subprocess stderr to `w` (default discarded). |
+
+## Lifecycle
+
+Each stdio server is a child process. `MCPToolset.Close()` terminates them; the CLI defers it for you when a run finishes. Long-lived embedders should `defer ts.Close()` alongside `defer orch.Close()`.
+
+## Security
+
+The settings file is a trust boundary. A stdio server entry runs its `command` as a local subprocess the moment the config loads - so an MCP config is as trusted as a `Makefile` or a `.vscode/tasks.json`. The spawn happens at load time, ahead of the tool-call permission gate (`--yolo` / `--allow` / `--sandbox`), which governs *tool invocations*, not the server process itself.
+
+- **Only run zenflow in directories you trust.** The CLI auto-loads `.zenflow/settings.json` from the working directory and launches its stdio servers. Treat a checkout with an unfamiliar `.zenflow/settings.json` the way you would treat one with an unfamiliar build script. Use `--no-mcp` to skip loading, or `--mcp-config` to point at a file you control.
+- **Use `https` for remote servers carrying secrets.** A `Bearer` token on an `http://` URL is sent in cleartext; zenflow prints a warning when it sees this.
+- Keep tokens in environment variables and reference them with `${VAR}` - never commit a literal secret in the file.
+
+zenflow runs stdio servers via an argument vector (no shell), so values in `args` are not subject to shell-injection; a server name containing the `__` separator is rejected (it would make tool namespacing ambiguous); and a server that fails to start never blocks the others.
+
+## Cross-links
+
+- [Tools](/concepts/tools) - how agents resolve tools; built-in, library-supplied, auto-injected, and MCP.
+- [Agents](/concepts/agents) - `tools` / `disallowedTools` allowlists.
+- [CLI flags](/cli/flags) - `--mcp-config`, `--no-mcp`.
+- [Go API: Options](/api/options) - `WithAdditionalTools` and the MCP functions.
+- [goai MCP docs](https://goai.sh) - the underlying client, transports, and auth.

--- a/docs/yaml/agent.md
+++ b/docs/yaml/agent.md
@@ -135,6 +135,7 @@ effective = (allowlist) - (denylist)
 - If `tools` is omitted, every tool registered with the orchestrator (via `WithTools`) is available to the agent.
 - `tools: [a, b, c]` means exactly those three.
 - `disallowedTools` removes entries from whatever the allowlist resolved to.
+- An [MCP](/integrations/mcp) **server name** in either list expands to all of that server's tools: `tools: [firecrawl]` grants every `firecrawl__*` tool. A specific MCP tool is grantable by its full `server__tool` name.
 
 ```yaml
 agents:
@@ -145,9 +146,13 @@ agents:
   builder:
     description: "Builder with most tools but no destructive bash."
     disallowedTools: ["bash"]
+
+  crawler:
+    description: "Crawls pages via the firecrawl MCP server."
+    tools: ["read", "write", "firecrawl"]   # 'firecrawl' = every firecrawl tool
 ```
 
-The CLI's default tool registry includes `bash`, `read`, `write`, `glob`, and `grep`. Library callers register their own via `zenflow.WithTools(...)`.
+The CLI's default tool registry includes `bash`, `read`, `write`, `glob`, and `grep`, plus any tools from [MCP servers](/integrations/mcp) declared in `settings.json`. Library callers register their own via `zenflow.WithTools(...)` / `zenflow.WithAdditionalTools(...)`. A tool (or MCP server) name that matches nothing in the catalog is rejected before the first LLM call with a `references unknown tool` error.
 
 ## maxTurns
 

--- a/internal/exec/agent_tool.go
+++ b/internal/exec/agent_tool.go
@@ -352,29 +352,34 @@ func (s *agentSpawner) SpawnChild(ctx context.Context, call provider.ToolCall) (
 // FilterTools returns a subset of tools based on allow/disallow lists.
 // If allow is non-empty, only tools whose names appear in allow are returned.
 // Tools whose names appear in disallow are always excluded.
+//
+// An entry also matches as an MCP server group: a bare server name
+// ("firecrawl") selects every tool that server contributed
+// ("firecrawl__scrape", "firecrawl__crawl", ...). Built-in and
+// auto-injected tool names contain no "__" separator, so group matching
+// never affects them.
 func FilterTools(tools []goai.Tool, allow, disallow []string) []goai.Tool {
-	dis := make(map[string]bool, len(disallow))
-	for _, name := range disallow {
-		dis[name] = true
-	}
-
-	var allowSet map[string]bool
-	if len(allow) > 0 {
-		allowSet = make(map[string]bool, len(allow))
-		for _, name := range allow {
-			allowSet[name] = true
-		}
-	}
-
 	result := make([]goai.Tool, 0, len(tools))
 	for _, t := range tools {
-		if dis[t.Name] {
+		if toolNameSelected(t.Name, disallow) {
 			continue
 		}
-		if allowSet != nil && !allowSet[t.Name] {
+		if len(allow) > 0 && !toolNameSelected(t.Name, allow) {
 			continue
 		}
 		result = append(result, t)
 	}
 	return result
+}
+
+// toolNameSelected reports whether toolName is selected by any entry in names,
+// either by exact match or as an MCP server group (entry "srv" matches
+// "srv__tool").
+func toolNameSelected(toolName string, names []string) bool {
+	for _, n := range names {
+		if n == toolName || mcpGroupMatches(toolName, n) {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/exec/goal_decomposer.go
+++ b/internal/exec/goal_decomposer.go
@@ -359,10 +359,29 @@ func ValidateToolNames(wf *Workflow, tools []goai.Tool) error {
 					Agent: name,
 				}
 			}
-			if !catalog[tool] {
-				return &ToolNotFoundError{Tool: tool, Agent: name}
+			if catalog[tool] {
+				continue
 			}
+			// An MCP server name ("firecrawl") is valid when the catalog
+			// holds at least one tool that server contributed
+			// ("firecrawl__scrape"). This lets an agent grant a whole
+			// server by its bare name without listing every tool.
+			if mcpGroupInCatalog(tool, tools) {
+				continue
+			}
+			return &ToolNotFoundError{Tool: tool, Agent: name}
 		}
 	}
 	return nil
+}
+
+// mcpGroupInCatalog reports whether entry names an MCP server with at least
+// one tool present in the catalog.
+func mcpGroupInCatalog(entry string, tools []goai.Tool) bool {
+	for _, t := range tools {
+		if mcpGroupMatches(t.Name, entry) {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/exec/mcp.go
+++ b/internal/exec/mcp.go
@@ -1,0 +1,380 @@
+package exec
+
+// mcp.go - native Model Context Protocol (MCP) support. zenflow reads a
+// Claude-compatible settings.json describing one or more MCP servers,
+// connects to each via goai's MCP client, and exposes their tools as
+// ordinary goai.Tool values. No tool-loop reimplementation lives here -
+// goai owns the wire protocol (mcp.Client) and the tool adapter
+// (mcp.ConvertTools); this file is the config -> clients -> tools glue
+// plus deterministic namespacing so multiple servers cannot collide.
+//
+// Discovered tools are namespaced "<server>__<tool>" so an agent's tool
+// allowlist can grant a whole server by its bare name (see FilterTools)
+// while individual tools stay addressable. The Execute closure built by
+// mcp.ConvertTools captures the server-side tool name, so renaming the
+// goai.Tool.Name for namespacing does not affect dispatch.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/zendev-sh/goai"
+	"github.com/zendev-sh/goai/mcp"
+)
+
+// MCPServerConfig describes a single MCP server entry. The shape matches the
+// Claude Desktop "mcpServers" convention so existing config
+// files port over unchanged. A stdio server sets Command (+ optional Args /
+// Env); a remote server sets URL (+ optional Headers). Type selects the
+// transport explicitly; when empty it is inferred (Command -> stdio,
+// URL -> http). String values in Command, Args, Env, URL, and Headers are
+// expanded with os.ExpandEnv, so "${FIRECRAWL_API_KEY}" resolves from the
+// process environment.
+type MCPServerConfig struct {
+	// Command is the executable for a stdio (local subprocess) server.
+	Command string `json:"command,omitempty"`
+	// Args are the arguments passed to Command.
+	Args []string `json:"args,omitempty"`
+	// Env sets additional environment variables for the subprocess. Merged
+	// onto the parent process environment.
+	Env map[string]string `json:"env,omitempty"`
+	// URL is the endpoint for a remote (http / sse) server.
+	URL string `json:"url,omitempty"`
+	// Headers are sent on every request to a remote server (e.g. auth).
+	Headers map[string]string `json:"headers,omitempty"`
+	// Type forces the transport: "stdio", "http", or "sse". Empty infers
+	// from Command / URL.
+	Type string `json:"type,omitempty"`
+	// Disabled skips this server entirely when true.
+	Disabled bool `json:"disabled,omitempty"`
+}
+
+// MCPConfig is the top-level settings.json document: a map of server name to
+// its configuration under the "mcpServers" key.
+type MCPConfig struct {
+	MCPServers map[string]MCPServerConfig `json:"mcpServers"`
+}
+
+// LoadMCPConfig reads and parses an MCP settings file. A missing file
+// returns an error satisfying errors.Is(err, os.ErrNotExist) so callers can
+// treat "no config" as a no-op without a separate stat. A present but
+// malformed file returns a parse error.
+func LoadMCPConfig(path string) (*MCPConfig, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		// %w preserves os.ErrNotExist for the documented errors.Is contract
+		// while keeping the package prefix on other read failures.
+		return nil, fmt.Errorf("zenflow: read MCP config %s: %w", path, err)
+	}
+	var cfg MCPConfig
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("zenflow: parse MCP config %s: %w", path, err)
+	}
+	return &cfg, nil
+}
+
+// MCPToolset is the live result of connecting to one or more MCP servers. It
+// owns the underlying clients (and, for stdio servers, their subprocesses);
+// callers MUST invoke Close to release them. Tools returns the aggregated,
+// namespaced goai.Tool slice ready for WithAdditionalTools.
+type MCPToolset struct {
+	tools   []goai.Tool
+	clients []*mcp.Client
+	servers []string
+}
+
+// Tools returns the discovered tools across all connected servers, each
+// named "<server>__<tool>". The slice is freshly allocated; mutating it does
+// not affect the toolset.
+func (t *MCPToolset) Tools() []goai.Tool {
+	if t == nil {
+		return nil
+	}
+	out := make([]goai.Tool, len(t.tools))
+	copy(out, t.tools)
+	return out
+}
+
+// Servers returns the names of the servers that connected successfully.
+func (t *MCPToolset) Servers() []string {
+	if t == nil {
+		return nil
+	}
+	out := make([]string, len(t.servers))
+	copy(out, t.servers)
+	return out
+}
+
+// Close shuts down every connected client, terminating stdio subprocesses.
+// Safe to call once; errors from individual closes are joined.
+func (t *MCPToolset) Close() error {
+	if t == nil {
+		return nil
+	}
+	var errs []error
+	for _, c := range t.clients {
+		if err := c.Close(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// mcpConnectConfig holds the resolved options for ConnectMCPConfig.
+type mcpConnectConfig struct {
+	clientName     string
+	clientVersion  string
+	requestTimeout time.Duration
+	stderr         io.Writer
+	// transportFactory is an unexported test seam. When nil, the default
+	// stdio/http/sse factory derived from MCPServerConfig is used.
+	transportFactory func(name string, sc MCPServerConfig) (mcp.Transport, error)
+}
+
+// MCPOption configures ConnectMCPConfig.
+type MCPOption func(*mcpConnectConfig)
+
+// WithMCPClientInfo sets the client name/version advertised to MCP servers
+// during the initialize handshake. Defaults to "zenflow"/"1.0.0".
+func WithMCPClientInfo(name, version string) MCPOption {
+	return func(c *mcpConnectConfig) {
+		if name != "" {
+			c.clientName = name
+		}
+		if version != "" {
+			c.clientVersion = version
+		}
+	}
+}
+
+// WithMCPRequestTimeout bounds each MCP request, including the connect
+// handshake and every subsequent tool call. Zero leaves goai's default
+// (60s). Note: for stdio servers this does NOT bound the subprocess
+// lifetime - that is governed by the context passed to ConnectMCPConfig and
+// by MCPToolset.Close.
+func WithMCPRequestTimeout(d time.Duration) MCPOption {
+	return func(c *mcpConnectConfig) { c.requestTimeout = d }
+}
+
+// WithMCPStderr routes the stderr of stdio MCP subprocesses to w (e.g. for
+// verbose diagnostics). Default discards it.
+func WithMCPStderr(w io.Writer) MCPOption {
+	return func(c *mcpConnectConfig) { c.stderr = w }
+}
+
+// withMCPTransportFactory injects a transport factory (test seam).
+func withMCPTransportFactory(f func(name string, sc MCPServerConfig) (mcp.Transport, error)) MCPOption {
+	return func(c *mcpConnectConfig) { c.transportFactory = f }
+}
+
+// ConnectMCPConfig connects to every (enabled) server in cfg and returns a
+// toolset aggregating their tools. Servers are processed in deterministic
+// (sorted) order. A failure connecting to one server does not abort the
+// others: the returned toolset contains the tools from all servers that
+// connected, and the returned error is the join of per-server failures
+// (nil when all succeed). Callers should use the toolset even on a non-nil
+// error and always Close it.
+//
+// For stdio servers, ctx governs the subprocess lifetime (goai starts them
+// with exec.CommandContext): pass a context that stays valid for as long as
+// the tools may be invoked, and rely on MCPToolset.Close - not context
+// cancellation - for orderly shutdown. A short-lived/timeout context would
+// kill the subprocess immediately after the handshake.
+func ConnectMCPConfig(ctx context.Context, cfg *MCPConfig, opts ...MCPOption) (*MCPToolset, error) {
+	cc := mcpConnectConfig{clientName: "zenflow", clientVersion: "1.0.0"}
+	for _, o := range opts {
+		o(&cc)
+	}
+
+	ts := &MCPToolset{}
+	if cfg == nil || len(cfg.MCPServers) == 0 {
+		return ts, nil
+	}
+
+	names := make([]string, 0, len(cfg.MCPServers))
+	for name := range cfg.MCPServers {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	var errs []error
+	for _, name := range names {
+		sc := cfg.MCPServers[name]
+		if sc.Disabled {
+			continue
+		}
+		// Reject names containing the namespace separator: they would make
+		// "<server>__<tool>" prefixes ambiguous between distinct servers, so
+		// an agent's bare-server-name grant could no longer be resolved
+		// unambiguously.
+		if strings.Contains(name, mcpNameSep) {
+			errs = append(errs, fmt.Errorf("mcp server %q: name must not contain %q", name, mcpNameSep))
+			continue
+		}
+		tools, client, err := cc.connectOne(ctx, name, sc)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("mcp server %q: %w", name, err))
+			continue
+		}
+		ts.clients = append(ts.clients, client)
+		ts.servers = append(ts.servers, name)
+		ts.tools = append(ts.tools, tools...)
+	}
+	return ts, errors.Join(errs...)
+}
+
+// connectOne connects to a single server and returns its namespaced tools.
+func (cc mcpConnectConfig) connectOne(ctx context.Context, name string, sc MCPServerConfig) ([]goai.Tool, *mcp.Client, error) {
+	factory := cc.transportFactory
+	if factory == nil {
+		factory = func(n string, s MCPServerConfig) (mcp.Transport, error) {
+			return defaultMCPTransport(n, s, cc.stderr)
+		}
+	}
+	transport, err := factory(name, sc)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	clientOpts := []mcp.ClientOption{mcp.WithTransport(transport)}
+	if cc.requestTimeout > 0 {
+		clientOpts = append(clientOpts, mcp.WithRequestTimeout(cc.requestTimeout))
+	}
+	client := mcp.NewClient(cc.clientName, cc.clientVersion, clientOpts...)
+
+	if err := client.Connect(ctx); err != nil {
+		_ = client.Close()
+		return nil, nil, err
+	}
+
+	mcpTools, err := listAllMCPTools(ctx, client)
+	if err != nil {
+		_ = client.Close()
+		return nil, nil, err
+	}
+
+	tools := mcp.ConvertTools(client, mcpTools)
+	prefix := name + mcpNameSep
+	for i := range tools {
+		tools[i].Name = prefix + tools[i].Name
+	}
+	return tools, client, nil
+}
+
+// listAllMCPTools collects a server's full tool list, following pagination.
+func listAllMCPTools(ctx context.Context, client *mcp.Client) ([]mcp.Tool, error) {
+	res, err := client.ListTools(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	all := res.Tools
+	for res.NextCursor != "" {
+		cursor := res.NextCursor
+		res, err = client.ListTools(ctx, &mcp.ListParams{Cursor: cursor})
+		if err != nil {
+			return nil, err
+		}
+		all = append(all, res.Tools...)
+		// Guard against a server that returns the same cursor forever (an
+		// unbounded loop on untrusted input). A well-behaved server either
+		// advances the cursor or clears it to end pagination.
+		if res.NextCursor == cursor {
+			return nil, fmt.Errorf("mcp: tools/list cursor did not advance (stuck at %q)", cursor)
+		}
+	}
+	return all, nil
+}
+
+// defaultMCPTransport builds the goai transport for a server config. stderr,
+// when non-nil, captures a stdio subprocess's stderr stream.
+func defaultMCPTransport(name string, sc MCPServerConfig, stderr io.Writer) (mcp.Transport, error) {
+	typ := sc.Type
+	if typ == "" {
+		switch {
+		case sc.Command != "":
+			typ = "stdio"
+		case sc.URL != "":
+			typ = "http"
+		default:
+			return nil, fmt.Errorf("config has neither command (stdio) nor url (http/sse)")
+		}
+	}
+
+	switch typ {
+	case "stdio":
+		if sc.Command == "" {
+			return nil, fmt.Errorf("stdio transport requires a command")
+		}
+		var stdioOpts []mcp.StdioOption
+		if len(sc.Env) > 0 {
+			stdioOpts = append(stdioOpts, mcp.WithStdioEnv(expandEnvMap(sc.Env)))
+		}
+		if stderr != nil {
+			stdioOpts = append(stdioOpts, mcp.WithStdioStderr(stderr))
+		}
+		return mcp.NewStdioTransport(os.ExpandEnv(sc.Command), expandEnvSlice(sc.Args), stdioOpts...), nil
+	case "http":
+		if sc.URL == "" {
+			return nil, fmt.Errorf("http transport requires a url")
+		}
+		var httpOpts []mcp.HTTPTransportOption
+		if len(sc.Headers) > 0 {
+			httpOpts = append(httpOpts, mcp.WithHTTPHeaders(expandEnvMap(sc.Headers)))
+		}
+		return mcp.NewHTTPTransport(os.ExpandEnv(sc.URL), httpOpts...), nil
+	case "sse":
+		if sc.URL == "" {
+			return nil, fmt.Errorf("sse transport requires a url")
+		}
+		var sseOpts []mcp.SSETransportOption
+		if len(sc.Headers) > 0 {
+			sseOpts = append(sseOpts, mcp.WithSSEHeaders(expandEnvMap(sc.Headers)))
+		}
+		return mcp.NewSSETransport(os.ExpandEnv(sc.URL), sseOpts...), nil
+	default:
+		return nil, fmt.Errorf("unknown transport type %q (want stdio, http, or sse)", typ)
+	}
+}
+
+// expandEnvSlice applies os.ExpandEnv to each element.
+func expandEnvSlice(in []string) []string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]string, len(in))
+	for i, s := range in {
+		out[i] = os.ExpandEnv(s)
+	}
+	return out
+}
+
+// expandEnvMap applies os.ExpandEnv to each value.
+func expandEnvMap(in map[string]string) map[string]string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(in))
+	for k, v := range in {
+		out[k] = os.ExpandEnv(v)
+	}
+	return out
+}
+
+// mcpNameSep is the separator between an MCP server name and its tool name in
+// the namespaced tool identifier. Built-in and auto-injected tool names never
+// contain it, so server grouping (FilterTools / ValidateToolNames) cannot
+// false-match a non-MCP tool.
+const mcpNameSep = "__"
+
+// mcpGroupMatches reports whether entry selects toolName as an MCP server
+// group: entry "firecrawl" matches every tool named "firecrawl__<tool>".
+func mcpGroupMatches(toolName, entry string) bool {
+	return strings.HasPrefix(toolName, entry+mcpNameSep)
+}

--- a/internal/exec/mcp_test.go
+++ b/internal/exec/mcp_test.go
@@ -1,0 +1,528 @@
+package exec
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/zendev-sh/goai"
+	"github.com/zendev-sh/goai/mcp"
+)
+
+// fakeMCPTransport is an in-process mcp.Transport that answers the MCP
+// handshake plus tools/list (with optional pagination) and tools/call from
+// canned data. It lets us exercise ConnectMCPConfig end to end without a real
+// subprocess.
+type fakeMCPTransport struct {
+	tools         []mcp.Tool
+	pageSize      int    // 0 => single page
+	startErr      error  // returned from Start
+	listErr       bool   // tools/list replies with a JSON-RPC error
+	listErrOnCall int32  // if >0, the Nth tools/list call errors (1-based)
+	stuckCursor   bool   // always return the same non-empty cursor (never ends)
+	closeErr      error  // returned from Close
+	callReply     string // text content returned from tools/call
+	noTools       bool   // advertise no tools capability (assertCapability fails)
+
+	listCalls atomic.Int32
+	onMessage func(mcp.JSONRPCMessage)
+	closed    bool
+}
+
+func (f *fakeMCPTransport) Start(_ context.Context) error         { return f.startErr }
+func (f *fakeMCPTransport) OnMessage(fn func(mcp.JSONRPCMessage)) { f.onMessage = fn }
+func (f *fakeMCPTransport) OnClose(func())                        {}
+func (f *fakeMCPTransport) OnError(func(error))                   {}
+func (f *fakeMCPTransport) Close() error                          { f.closed = true; return f.closeErr }
+
+// mcpToolNames extracts the names from a goai.Tool slice for assertions.
+func mcpToolNames(tools []goai.Tool) []string {
+	out := make([]string, len(tools))
+	for i, t := range tools {
+		out[i] = t.Name
+	}
+	return out
+}
+
+func (f *fakeMCPTransport) reply(id any, result any) {
+	raw, _ := json.Marshal(result)
+	f.onMessage(mcp.JSONRPCMessage{JSONRPC: "2.0", ID: id, Result: raw})
+}
+
+func (f *fakeMCPTransport) replyError(id any, code int, msg string) {
+	f.onMessage(mcp.JSONRPCMessage{JSONRPC: "2.0", ID: id, RPCError: &mcp.JSONRPCError{Code: code, Message: msg}})
+}
+
+func (f *fakeMCPTransport) Send(_ context.Context, msg mcp.JSONRPCMessage) error {
+	go func() {
+		switch msg.Method {
+		case "initialize":
+			caps := mcp.ServerCapabilities{}
+			if !f.noTools {
+				caps.Tools = &mcp.ToolsCapability{}
+			}
+			f.reply(msg.ID, mcp.InitializeResult{
+				ProtocolVersion: mcp.ProtocolVersion20250326,
+				Capabilities:    caps,
+				ServerInfo:      mcp.ServerInfo{Name: "fake", Version: "1.0"},
+			})
+		case "notifications/initialized":
+			// notification: no response
+		case "tools/list":
+			call := f.listCalls.Add(1)
+			if f.listErr || (f.listErrOnCall > 0 && call == f.listErrOnCall) {
+				f.replyError(msg.ID, -32000, "list failed")
+				return
+			}
+			start := 0
+			if len(msg.Params) > 0 {
+				var p mcp.ListParams
+				_ = json.Unmarshal(msg.Params, &p)
+				if p.Cursor != "" {
+					start, _ = strconv.Atoi(p.Cursor)
+				}
+			}
+			if f.stuckCursor {
+				f.reply(msg.ID, mcp.ListToolsResult{Tools: f.tools, NextCursor: "stuck"})
+				return
+			}
+			end := len(f.tools)
+			next := ""
+			if f.pageSize > 0 && start+f.pageSize < len(f.tools) {
+				end = start + f.pageSize
+				next = strconv.Itoa(end)
+			}
+			f.reply(msg.ID, mcp.ListToolsResult{Tools: f.tools[start:end], NextCursor: next})
+		case "tools/call":
+			block, _ := json.Marshal(mcp.TextContent{Type: "text", Text: f.callReply})
+			f.reply(msg.ID, mcp.CallToolResult{Content: []mcp.ContentBlock{block}})
+		}
+	}()
+	return nil
+}
+
+func mcpTool(name string) mcp.Tool {
+	return mcp.Tool{Name: name, Description: "desc", InputSchema: json.RawMessage(`{"type":"object"}`)}
+}
+
+func fakeFactory(transports map[string]*fakeMCPTransport) func(string, MCPServerConfig) (mcp.Transport, error) {
+	return func(name string, _ MCPServerConfig) (mcp.Transport, error) {
+		t, ok := transports[name]
+		if !ok {
+			return nil, errors.New("no fake transport for " + name)
+		}
+		return t, nil
+	}
+}
+
+func TestConnectMCPConfig_NamespacesAndAggregates(t *testing.T) {
+	ft := map[string]*fakeMCPTransport{
+		"alpha": {tools: []mcp.Tool{mcpTool("scrape"), mcpTool("crawl")}, callReply: "alpha-ok"},
+		"beta":  {tools: []mcp.Tool{mcpTool("scrape")}, callReply: "beta-ok"},
+	}
+	cfg := &MCPConfig{MCPServers: map[string]MCPServerConfig{
+		"alpha": {Command: "x"},
+		"beta":  {Command: "y"},
+	}}
+
+	ts, err := ConnectMCPConfig(context.Background(), cfg, withMCPTransportFactory(fakeFactory(ft)))
+	if err != nil {
+		t.Fatalf("ConnectMCPConfig: %v", err)
+	}
+	defer ts.Close()
+
+	got := mcpToolNames(ts.Tools())
+	want := []string{"alpha__scrape", "alpha__crawl", "beta__scrape"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("tool names = %v, want %v", got, want)
+	}
+	if servers := ts.Servers(); strings.Join(servers, ",") != "alpha,beta" {
+		t.Fatalf("servers = %v, want [alpha beta]", servers)
+	}
+
+	// The namespaced tool dispatches to the server-side name "scrape" and
+	// returns the fake's canned content.
+	out, err := ts.Tools()[0].Execute(context.Background(), json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if out != "alpha-ok" {
+		t.Errorf("Execute result = %q, want alpha-ok", out)
+	}
+}
+
+func TestConnectMCPConfig_Pagination(t *testing.T) {
+	ft := map[string]*fakeMCPTransport{
+		"srv": {tools: []mcp.Tool{mcpTool("a"), mcpTool("b"), mcpTool("c"), mcpTool("d"), mcpTool("e")}, pageSize: 2},
+	}
+	cfg := &MCPConfig{MCPServers: map[string]MCPServerConfig{"srv": {Command: "x"}}}
+	ts, err := ConnectMCPConfig(context.Background(), cfg, withMCPTransportFactory(fakeFactory(ft)))
+	if err != nil {
+		t.Fatalf("ConnectMCPConfig: %v", err)
+	}
+	defer ts.Close()
+	if got := len(ts.Tools()); got != 5 {
+		t.Fatalf("aggregated %d tools across pages, want 5", got)
+	}
+}
+
+func TestConnectMCPConfig_DisabledSkipped(t *testing.T) {
+	ft := map[string]*fakeMCPTransport{"on": {tools: []mcp.Tool{mcpTool("t")}}}
+	cfg := &MCPConfig{MCPServers: map[string]MCPServerConfig{
+		"on":  {Command: "x"},
+		"off": {Command: "y", Disabled: true},
+	}}
+	ts, err := ConnectMCPConfig(context.Background(), cfg, withMCPTransportFactory(fakeFactory(ft)))
+	if err != nil {
+		t.Fatalf("ConnectMCPConfig: %v", err)
+	}
+	defer ts.Close()
+	if got := ts.Servers(); len(got) != 1 || got[0] != "on" {
+		t.Fatalf("servers = %v, want [on]", got)
+	}
+}
+
+func TestConnectMCPConfig_PartialFailureJoined(t *testing.T) {
+	ft := map[string]*fakeMCPTransport{
+		"good": {tools: []mcp.Tool{mcpTool("t")}},
+		"bad":  {listErr: true},
+	}
+	cfg := &MCPConfig{MCPServers: map[string]MCPServerConfig{
+		"good": {Command: "x"},
+		"bad":  {Command: "y"},
+	}}
+	ts, err := ConnectMCPConfig(context.Background(), cfg, withMCPTransportFactory(fakeFactory(ft)))
+	if err == nil {
+		t.Fatal("expected joined error from bad server")
+	}
+	if !strings.Contains(err.Error(), `mcp server "bad"`) {
+		t.Errorf("error = %v, want mention of bad server", err)
+	}
+	defer ts.Close()
+	// good server still loaded.
+	if got := ts.Servers(); len(got) != 1 || got[0] != "good" {
+		t.Fatalf("servers = %v, want [good]", got)
+	}
+}
+
+func TestConnectMCPConfig_TransportFactoryError(t *testing.T) {
+	cfg := &MCPConfig{MCPServers: map[string]MCPServerConfig{"x": {Command: "c"}}}
+	ts, err := ConnectMCPConfig(context.Background(), cfg,
+		withMCPTransportFactory(func(string, MCPServerConfig) (mcp.Transport, error) {
+			return nil, errors.New("boom")
+		}))
+	if err == nil || !strings.Contains(err.Error(), "boom") {
+		t.Fatalf("err = %v, want boom", err)
+	}
+	if len(ts.Tools()) != 0 {
+		t.Errorf("expected no tools on factory failure")
+	}
+}
+
+func TestConnectMCPConfig_NilAndEmpty(t *testing.T) {
+	for _, cfg := range []*MCPConfig{nil, {}, {MCPServers: map[string]MCPServerConfig{}}} {
+		ts, err := ConnectMCPConfig(context.Background(), cfg)
+		if err != nil {
+			t.Fatalf("err = %v, want nil", err)
+		}
+		if len(ts.Tools()) != 0 || len(ts.Servers()) != 0 {
+			t.Errorf("expected empty toolset")
+		}
+		if err := ts.Close(); err != nil {
+			t.Errorf("Close: %v", err)
+		}
+	}
+}
+
+func TestConnectMCPConfig_ConnectError(t *testing.T) {
+	ft := map[string]*fakeMCPTransport{"x": {startErr: errors.New("spawn failed")}}
+	cfg := &MCPConfig{MCPServers: map[string]MCPServerConfig{"x": {Command: "c"}}}
+	_, err := ConnectMCPConfig(context.Background(), cfg, withMCPTransportFactory(fakeFactory(ft)))
+	if err == nil || !strings.Contains(err.Error(), "spawn failed") {
+		t.Fatalf("err = %v, want spawn failed", err)
+	}
+}
+
+func TestMCPToolset_CloseClosesClients(t *testing.T) {
+	ft := map[string]*fakeMCPTransport{"x": {tools: []mcp.Tool{mcpTool("t")}}}
+	cfg := &MCPConfig{MCPServers: map[string]MCPServerConfig{"x": {Command: "c"}}}
+	ts, _ := ConnectMCPConfig(context.Background(), cfg, withMCPTransportFactory(fakeFactory(ft)))
+	if err := ts.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if !ft["x"].closed {
+		t.Error("transport not closed")
+	}
+}
+
+func TestMCPToolset_NilReceiver(t *testing.T) {
+	var ts *MCPToolset
+	if ts.Tools() != nil || ts.Servers() != nil || ts.Close() != nil {
+		t.Error("nil receiver methods should be safe no-ops")
+	}
+}
+
+func TestConnectMCPConfig_ClientInfoAndStderrOptions(t *testing.T) {
+	// Exercise the option setters and the requestTimeout client-option path.
+	ft := map[string]*fakeMCPTransport{"x": {tools: []mcp.Tool{mcpTool("t")}}}
+	cfg := &MCPConfig{MCPServers: map[string]MCPServerConfig{"x": {Command: "c"}}}
+	var sb strings.Builder
+	ts, err := ConnectMCPConfig(context.Background(), cfg,
+		WithMCPClientInfo("custom", "9.9"),
+		WithMCPClientInfo("", ""), // empty args ignored
+		WithMCPStderr(&sb),
+		WithMCPRequestTimeout(0), // zero leaves default
+		withMCPTransportFactory(fakeFactory(ft)),
+	)
+	if err != nil {
+		t.Fatalf("ConnectMCPConfig: %v", err)
+	}
+	ts.Close()
+	if len(ts.Tools()) != 1 {
+		t.Fatalf("tools = %d, want 1", len(ts.Tools()))
+	}
+}
+
+func TestDefaultMCPTransport(t *testing.T) {
+	t.Setenv("MCP_TEST_TOKEN", "secret")
+	tests := []struct {
+		name    string
+		sc      MCPServerConfig
+		wantErr string
+	}{
+		{"stdio inferred", MCPServerConfig{Command: "npx", Args: []string{"-y", "${MCP_TEST_TOKEN}"}, Env: map[string]string{"K": "${MCP_TEST_TOKEN}"}}, ""},
+		{"stdio explicit stderr", MCPServerConfig{Type: "stdio", Command: "x"}, ""},
+		{"http inferred", MCPServerConfig{URL: "http://localhost", Headers: map[string]string{"A": "${MCP_TEST_TOKEN}"}}, ""},
+		{"http explicit", MCPServerConfig{Type: "http", URL: "http://x"}, ""},
+		{"sse", MCPServerConfig{Type: "sse", URL: "http://x", Headers: map[string]string{"A": "b"}}, ""},
+		{"empty config", MCPServerConfig{}, "neither command"},
+		{"stdio no command", MCPServerConfig{Type: "stdio"}, "requires a command"},
+		{"http no url", MCPServerConfig{Type: "http"}, "requires a url"},
+		{"sse no url", MCPServerConfig{Type: "sse"}, "requires a url"},
+		{"unknown type", MCPServerConfig{Type: "carrier-pigeon", Command: "x"}, "unknown transport type"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var sb strings.Builder
+			tr, err := defaultMCPTransport(tt.name, tt.sc, &sb)
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("err = %v, want contains %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected err: %v", err)
+			}
+			if tr == nil {
+				t.Fatal("nil transport")
+			}
+		})
+	}
+}
+
+func TestExpandEnvHelpers(t *testing.T) {
+	t.Setenv("ZF_X", "val")
+	if got := expandEnvSlice(nil); got != nil {
+		t.Errorf("expandEnvSlice(nil) = %v", got)
+	}
+	if got := expandEnvSlice([]string{"a", "${ZF_X}"}); got[1] != "val" {
+		t.Errorf("expandEnvSlice = %v", got)
+	}
+	if got := expandEnvMap(nil); got != nil {
+		t.Errorf("expandEnvMap(nil) = %v", got)
+	}
+	if got := expandEnvMap(map[string]string{"k": "${ZF_X}"}); got["k"] != "val" {
+		t.Errorf("expandEnvMap = %v", got)
+	}
+}
+
+func TestLoadMCPConfig(t *testing.T) {
+	dir := t.TempDir()
+
+	// Valid.
+	good := filepath.Join(dir, "good.json")
+	if err := os.WriteFile(good, []byte(`{"mcpServers":{"fs":{"command":"npx","args":["-y","x"]}}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := LoadMCPConfig(good)
+	if err != nil {
+		t.Fatalf("LoadMCPConfig: %v", err)
+	}
+	if cfg.MCPServers["fs"].Command != "npx" {
+		t.Errorf("parsed command = %q", cfg.MCPServers["fs"].Command)
+	}
+
+	// Missing -> os.ErrNotExist.
+	_, err = LoadMCPConfig(filepath.Join(dir, "nope.json"))
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("missing file err = %v, want ErrNotExist", err)
+	}
+
+	// Malformed.
+	bad := filepath.Join(dir, "bad.json")
+	_ = os.WriteFile(bad, []byte(`{not json`), 0o600)
+	_, err = LoadMCPConfig(bad)
+	if err == nil || !strings.Contains(err.Error(), "parse MCP config") {
+		t.Errorf("malformed err = %v", err)
+	}
+}
+
+func TestConnectMCPConfig_PaginationErrorPropagates(t *testing.T) {
+	// First page OK with a NextCursor, second page errors.
+	ft := map[string]*fakeMCPTransport{
+		"srv": {tools: []mcp.Tool{mcpTool("a"), mcpTool("b"), mcpTool("c")}, pageSize: 1, listErrOnCall: 2},
+	}
+	cfg := &MCPConfig{MCPServers: map[string]MCPServerConfig{"srv": {Command: "x"}}}
+	ts, err := ConnectMCPConfig(context.Background(), cfg, withMCPTransportFactory(fakeFactory(ft)))
+	if err == nil || !strings.Contains(err.Error(), "list failed") {
+		t.Fatalf("err = %v, want list failed", err)
+	}
+	if len(ts.Tools()) != 0 {
+		t.Errorf("partial pagination must not yield tools")
+	}
+}
+
+func TestConnectMCPConfig_DefaultFactoryRealSpawnFails(t *testing.T) {
+	// No injected factory: ConnectMCPConfig builds a real stdio transport via
+	// defaultMCPTransport and tries to spawn the command, which does not exist.
+	cfg := &MCPConfig{MCPServers: map[string]MCPServerConfig{
+		"ghost": {Command: "zenflow-no-such-mcp-binary-xyz"},
+	}}
+	ts, err := ConnectMCPConfig(context.Background(), cfg)
+	if err == nil {
+		t.Fatal("expected connect error for nonexistent command")
+	}
+	if !strings.Contains(err.Error(), `mcp server "ghost"`) {
+		t.Errorf("err = %v, want mention of ghost server", err)
+	}
+	if len(ts.Tools()) != 0 {
+		t.Error("expected no tools")
+	}
+}
+
+func TestConnectMCPConfig_RequestTimeoutOption(t *testing.T) {
+	ft := map[string]*fakeMCPTransport{"x": {tools: []mcp.Tool{mcpTool("t")}}}
+	cfg := &MCPConfig{MCPServers: map[string]MCPServerConfig{"x": {Command: "c"}}}
+	ts, err := ConnectMCPConfig(context.Background(), cfg,
+		WithMCPRequestTimeout(5*time.Second),
+		withMCPTransportFactory(fakeFactory(ft)))
+	if err != nil {
+		t.Fatalf("ConnectMCPConfig: %v", err)
+	}
+	defer ts.Close()
+	if len(ts.Tools()) != 1 {
+		t.Fatalf("tools = %d, want 1", len(ts.Tools()))
+	}
+}
+
+func TestMCPToolset_CloseJoinsErrors(t *testing.T) {
+	ft := map[string]*fakeMCPTransport{"x": {tools: []mcp.Tool{mcpTool("t")}, closeErr: errors.New("close boom")}}
+	cfg := &MCPConfig{MCPServers: map[string]MCPServerConfig{"x": {Command: "c"}}}
+	ts, _ := ConnectMCPConfig(context.Background(), cfg, withMCPTransportFactory(fakeFactory(ft)))
+	if err := ts.Close(); err == nil || !strings.Contains(err.Error(), "close boom") {
+		t.Fatalf("Close err = %v, want close boom", err)
+	}
+}
+
+func TestWithAdditionalTools_Appends(t *testing.T) {
+	o := &Orchestrator{}
+	WithTools(makeTool("read", "", "ok"))(o)
+	WithAdditionalTools(makeTool("firecrawl__scrape", "", "ok"), makeTool("firecrawl__crawl", "", "ok"))(o)
+	got := mcpToolNames(o.tools)
+	want := []string{"read", "firecrawl__scrape", "firecrawl__crawl"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("tools = %v, want %v", got, want)
+	}
+}
+
+func TestFilterTools_MCPServerGroup(t *testing.T) {
+	catalog := []goai.Tool{
+		makeTool("read", "", "ok"),
+		makeTool("firecrawl__scrape", "", "ok"),
+		makeTool("firecrawl__crawl", "", "ok"),
+		makeTool("github__search", "", "ok"),
+	}
+	// Bare server name grants every tool of that server, plus an exact name.
+	got := mcpToolNames(FilterTools(catalog, []string{"read", "firecrawl"}, nil))
+	want := []string{"read", "firecrawl__scrape", "firecrawl__crawl"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("allow group = %v, want %v", got, want)
+	}
+	// Disallow a server group.
+	got = mcpToolNames(FilterTools(catalog, nil, []string{"firecrawl"}))
+	want = []string{"read", "github__search"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("disallow group = %v, want %v", got, want)
+	}
+}
+
+func TestValidateToolNames_MCPServerGroup(t *testing.T) {
+	catalog := []goai.Tool{
+		makeTool("read", "", "ok"),
+		makeTool("firecrawl__scrape", "", "ok"),
+	}
+	// Bare server group "firecrawl" is valid because a namespaced tool exists.
+	okWF := &Workflow{Agents: map[string]AgentConfig{
+		"a": {Tools: []string{"read", "firecrawl"}},
+	}}
+	if err := ValidateToolNames(okWF, catalog); err != nil {
+		t.Errorf("expected group reference to validate, got %v", err)
+	}
+	// An unknown server group is rejected.
+	badWF := &Workflow{Agents: map[string]AgentConfig{
+		"a": {Tools: []string{"slack"}},
+	}}
+	if err := ValidateToolNames(badWF, catalog); err == nil {
+		t.Error("expected unknown group to fail validation")
+	}
+}
+
+func TestConnectMCPConfig_RejectsServerNameWithSeparator(t *testing.T) {
+	ft := map[string]*fakeMCPTransport{"good": {tools: []mcp.Tool{mcpTool("t")}}}
+	cfg := &MCPConfig{MCPServers: map[string]MCPServerConfig{
+		"good": {Command: "x"},
+		"a__b": {Command: "y"}, // name contains the namespace separator
+	}}
+	ts, err := ConnectMCPConfig(context.Background(), cfg, withMCPTransportFactory(fakeFactory(ft)))
+	if err == nil || !strings.Contains(err.Error(), `must not contain "__"`) {
+		t.Fatalf("err = %v, want rejection of \"a__b\"", err)
+	}
+	defer ts.Close()
+	// The valid server still loads.
+	if got := ts.Servers(); len(got) != 1 || got[0] != "good" {
+		t.Fatalf("servers = %v, want [good]", got)
+	}
+}
+
+func TestConnectMCPConfig_StuckCursorErrors(t *testing.T) {
+	ft := map[string]*fakeMCPTransport{"srv": {tools: []mcp.Tool{mcpTool("a")}, stuckCursor: true}}
+	cfg := &MCPConfig{MCPServers: map[string]MCPServerConfig{"srv": {Command: "x"}}}
+	ts, err := ConnectMCPConfig(context.Background(), cfg, withMCPTransportFactory(fakeFactory(ft)))
+	if err == nil || !strings.Contains(err.Error(), "cursor did not advance") {
+		t.Fatalf("err = %v, want stuck-cursor error", err)
+	}
+	defer ts.Close()
+	if len(ts.Tools()) != 0 {
+		t.Error("expected no tools from a stuck-cursor server")
+	}
+}
+
+func TestMCPGroupMatches(t *testing.T) {
+	if !mcpGroupMatches("firecrawl__scrape", "firecrawl") {
+		t.Error("expected group match")
+	}
+	if mcpGroupMatches("read", "read") {
+		t.Error("exact name without separator should not group-match")
+	}
+	if mcpGroupMatches("firecrawlX__y", "firecrawl") {
+		t.Error("prefix without separator boundary should not match")
+	}
+}

--- a/internal/exec/options.go
+++ b/internal/exec/options.go
@@ -76,6 +76,16 @@ func WithTools(tools ...goai.Tool) Option {
 	return func(o *Orchestrator) { o.tools = tools }
 }
 
+// WithAdditionalTools appends tools to the orchestrator catalog instead of
+// replacing it. Unlike WithTools (which overwrites the whole slice), this
+// composes onto whatever WithTools installed earlier in the option list -
+// the canonical way to layer MCP-discovered tools (see ConnectMCPConfig)
+// or plugin tools on top of a built-in set without rebuilding the slice.
+// Stable.
+func WithAdditionalTools(tools ...goai.Tool) Option {
+	return func(o *Orchestrator) { o.tools = append(o.tools, tools...) }
+}
+
 // WithGoAIOptions passes extra goai options to GenerateText calls.
 // Stable.
 func WithGoAIOptions(opts ...goai.Option) Option {

--- a/internal/exec/zenflow.go
+++ b/internal/exec/zenflow.go
@@ -600,6 +600,14 @@ func (o *Orchestrator) runFlowWithID(ctx context.Context, wf *Workflow, runID st
 	if o.model == nil {
 		return nil, ErrModelRequired
 	}
+	// Reject agents referencing tools the catalog does not provide BEFORE
+	// the first LLM call. RunGoal validates its generated workflow earlier;
+	// direct RunFlow runs validate here so a typo (or an MCP server that
+	// failed to load) surfaces as a clear load-time ToolNotFoundError
+	// instead of silently dropping the tool and confusing the agent.
+	if err := ValidateToolNames(wf, o.tools); err != nil {
+		return nil, err
+	}
 
 	// Start flow trace span at Orchestrator level.
 	if o.tracer != nil {

--- a/internal/exec/zenflow_test.go
+++ b/internal/exec/zenflow_test.go
@@ -138,7 +138,15 @@ func TestRunFlow_Integration(t *testing.T) {
 			{Text: "review done", Usage: provider.Usage{InputTokens: 15, OutputTokens: 8}},
 		},
 	}
-	var tools []goai.Tool
+	// testWorkflowYAML's coder agent references read/write/bash/grep; register
+	// them so flow-path ValidateToolNames passes (the contract: agents may
+	// only reference tools present in the orchestrator catalog).
+	tools := []goai.Tool{
+		makeTool("read", "read", "ok"),
+		makeTool("write", "write", "ok"),
+		makeTool("bash", "bash", "ok"),
+		makeTool("grep", "grep", "ok"),
+	}
 
 	zf := New(
 		WithModel(llm),
@@ -1051,6 +1059,14 @@ func TestRunFlow_EmitsPlanReadyBeforeExecute(t *testing.T) {
 		WithModel(llm),
 		WithProgress(rec),
 		WithDefaultModel("gpt-4o"),
+		// Register the tools testWorkflowYAML's coder references so flow-path
+		// ValidateToolNames passes.
+		WithTools(
+			makeTool("read", "read", "ok"),
+			makeTool("write", "write", "ok"),
+			makeTool("bash", "bash", "ok"),
+			makeTool("grep", "grep", "ok"),
+		),
 	)
 	wf, err := ParseWorkflow([]byte(testWorkflowYAML))
 	if err != nil {

--- a/mcp_facade.go
+++ b/mcp_facade.go
@@ -1,0 +1,44 @@
+package zenflow
+
+// mcp_facade.go - root re-exports for the native MCP (Model Context Protocol)
+// surface implemented in internal/exec/mcp.go. Embedders load a Claude-
+// compatible settings.json, connect to the declared servers, and layer the
+// discovered tools onto the orchestrator with WithAdditionalTools:
+//
+//	cfg, err := zenflow.LoadMCPConfig(".zenflow/settings.json")
+//	if err != nil { /* errors.Is(err, os.ErrNotExist) => no MCP configured */ }
+//	ts, err := zenflow.ConnectMCPConfig(ctx, cfg)
+//	defer ts.Close()
+//	orch := zenflow.New(
+//	    zenflow.WithModel(llm),
+//	    zenflow.WithTools(builtins...),
+//	    zenflow.WithAdditionalTools(ts.Tools()...),
+//	)
+
+import "github.com/zendev-sh/zenflow/internal/exec"
+
+// MCP config + result types re-exported from internal/exec.
+type (
+	// MCPServerConfig describes one MCP server (stdio or remote).
+	MCPServerConfig = exec.MCPServerConfig
+	// MCPConfig is the parsed settings.json document.
+	MCPConfig = exec.MCPConfig
+	// MCPToolset owns live MCP clients and exposes their tools.
+	MCPToolset = exec.MCPToolset
+	// MCPOption configures ConnectMCPConfig.
+	MCPOption = exec.MCPOption
+)
+
+// MCP functions + options re-exported from internal/exec.
+var (
+	// LoadMCPConfig reads and parses an MCP settings file.
+	LoadMCPConfig = exec.LoadMCPConfig
+	// ConnectMCPConfig connects to every server in a config and aggregates tools.
+	ConnectMCPConfig = exec.ConnectMCPConfig
+	// WithMCPClientInfo sets the advertised client name/version.
+	WithMCPClientInfo = exec.WithMCPClientInfo
+	// WithMCPRequestTimeout bounds each MCP request.
+	WithMCPRequestTimeout = exec.WithMCPRequestTimeout
+	// WithMCPStderr routes stdio subprocess stderr.
+	WithMCPStderr = exec.WithMCPStderr
+)

--- a/orchestrator_facade.go
+++ b/orchestrator_facade.go
@@ -52,6 +52,7 @@ var New = exec.New
 var (
 	WithModel                     = exec.WithModel
 	WithTools                     = exec.WithTools
+	WithAdditionalTools           = exec.WithAdditionalTools
 	WithGoAIOptions               = exec.WithGoAIOptions
 	WithStorage                   = exec.WithStorage
 	WithPermissions               = exec.WithPermissions

--- a/spec/v1/spec.md
+++ b/spec/v1/spec.md
@@ -78,7 +78,8 @@ The `tools` and `disallowedTools` fields control which tools an agent can use:
 - If `tools` is absent, tool availability is implementation-defined.
 - Wildcard tool names like `"*"` are not currently expanded -- they are parsed as literal tool identifiers that match nothing. To allow every registered tool, omit the `tools` field entirely.
 - If `tools` is a list of names, only those tools are allowed.
-- `disallowedTools` removes tools from the resolved allowlist.
+- A name that matches an MCP server (see the host's MCP configuration) expands to every tool that server contributed, which the host namespaces `<server>__<tool>`. A single MCP tool is selectable by its full namespaced name.
+- `disallowedTools` removes tools from the resolved allowlist (server-group names apply here too).
 
 The effective tool set is: `(allowlist) - (denylist)`.
 


### PR DESCRIPTION
## Summary

Native [Model Context Protocol](https://modelcontextprotocol.io) support. Point zenflow at a Claude-compatible `.zenflow/settings.json` and every declared MCP server's tools become available to agents — **no Go code, no recompile**. This is the feature requested in #14, and is conceptually adjacent to the external-tool-loading explored in #9 (`.so` plugins) but uses the MCP standard instead.

## What's included

- **Transports:** stdio (local subprocess), Streamable HTTP, and SSE — with `${VAR}` env expansion in `command`/`args`/`env`/`url`/`headers`.
- **Tool namespacing:** discovered tools are `<server>__<tool>`; an agent grants a whole server by its bare name in `tools:` (e.g. `tools: ["firecrawl"]`), or a single tool by full name. Built-in/coordinator tool names never contain `__`, so grouping can't collide with them.
- **Library API:** `LoadMCPConfig`, `ConnectMCPConfig`, `MCPToolset`, `WithMCPClientInfo/RequestTimeout/Stderr`, and `WithAdditionalTools` (appends onto the catalog instead of replacing it). Re-exported via a root facade.
- **CLI:** auto-loads `.zenflow/settings.json` for `flow`/`goal`/`agent` (`--mcp-config PATH`, `--no-mcp`); warns on plaintext-`http://` credentials; rejects server names containing `__`.
- **Resilience:** one unreachable server doesn't abort the rest; stuck-cursor pagination is rejected; stdio lifetime is owned by `MCPToolset.Close`.
- **Docs:** new MCP guide (stdio/HTTP/SSE, remote GitHub example, security/trust boundary, troubleshooting), plus updates to tools/agents/flags/options/spec, README, SKILL, and the homepage.

## Behavior change (for release notes)

The `flow` path now validates agent tool names before the first LLM call (it already did on the `goal` path). A workflow/agent referencing a tool the catalog doesn't hold — a typo, or a server that failed to load — now fails fast with `references unknown tool …` instead of silently dropping it. This aligns code with the documented contract, but is a behavior change for library embedders that called `RunFlow` with a sparse tool catalog.

## Testing

- Unit: in-process fake transport + an in-process `httptest` Streamable-HTTP MCP server. **100% coverage** on the new code; `-race` clean.
- Verified end-to-end against the real `@modelcontextprotocol/server-filesystem` (stdio) and GitHub's remote MCP server (HTTP, 44 tools) — e2e harness kept out of the public repo per project policy.

## Target release

0.2.0.

Refs #14, #9.