### PR TITLE
feat: ${VAR} environment-variable interpolation in workflow YAML (#16)

### DIFF
--- a/cmd/zenflow/cmd_agent.go
+++ b/cmd/zenflow/cmd_agent.go
@@ -17,7 +17,7 @@ import (
 func cmdAgent() {
 	a := osArgs()
 	if len(a) < 3 {
-		fmt.Fprintln(stderr, "usage: zenflow agent <prompt> [--model MODEL] [--max-turns N] [--max-depth N] [--workdir DIR] [--json] [--stream] [--thinking LEVEL] [--mcp-config PATH] [--no-mcp] [--verbose] [--yolo] [--sandbox] [--allow LIST] [--deny LIST] [--strict]")
+		fmt.Fprintln(stderr, "usage: zenflow agent <prompt> [--model MODEL] [--max-turns N] [--max-depth N] [--workdir DIR] [--json] [--stream] [--thinking LEVEL] [--mcp-config PATH] [--no-mcp] [--env-file PATH] [--no-dotenv] [--verbose] [--yolo] [--sandbox] [--allow LIST] [--deny LIST] [--strict]")
 		exit(3)
 		return
 	}
@@ -122,6 +122,9 @@ func cmdAgent() {
 		exit(3)
 		return
 	}
+	// Auto-load .env so ${VAR} in MCP config resolves from the operator's
+	// environment (issue #16).
+	loadDotEnv(flags)
 	// Use buildOrchestratorOpts for consistent LLM provider wiring.
 	opts := buildOrchestratorOpts(flags)
 	// Load MCP servers from settings.json and append their tools so the

--- a/cmd/zenflow/cmd_flow.go
+++ b/cmd/zenflow/cmd_flow.go
@@ -15,7 +15,7 @@ import (
 func cmdFlow() {
 	a := osArgs()
 	if len(a) < 3 {
-		fmt.Fprintln(stderr, "usage: zenflow flow <file> [<context>] [--model MODEL] [--timeout DURATION] [--max-concurrency N] [--max-depth N] [--resume RUN_ID] [--workdir DIR] [--json] [--quiet] [--summary-only] [--stream] [--plan] [--trace] [--thinking LEVEL] [--mcp-config PATH] [--no-mcp] [--verbose] [--yolo] [--sandbox] [--allow LIST] [--deny LIST] [--strict]")
+		fmt.Fprintln(stderr, "usage: zenflow flow <file> [<context>] [--model MODEL] [--timeout DURATION] [--max-concurrency N] [--max-depth N] [--resume RUN_ID] [--workdir DIR] [--json] [--quiet] [--summary-only] [--stream] [--plan] [--trace] [--thinking LEVEL] [--mcp-config PATH] [--no-mcp] [--env-file PATH] [--no-dotenv] [--verbose] [--yolo] [--sandbox] [--allow LIST] [--deny LIST] [--strict]")
 		exit(3)
 		return
 	}
@@ -53,6 +53,9 @@ func cmdFlow() {
 		exit(3)
 		return
 	}
+	// Auto-load .env into the process environment so ${VAR} references in
+	// the workflow YAML resolve during LoadWorkflow (issue #16).
+	loadDotEnv(flags)
 	wf, err := zenflow.LoadWorkflow(wfPath)
 	if err != nil {
 		fmt.Fprintf(stderr, "✗ %v\n", err)

--- a/cmd/zenflow/cmd_goal.go
+++ b/cmd/zenflow/cmd_goal.go
@@ -16,7 +16,7 @@ import (
 func cmdGoal() {
 	a := osArgs()
 	if len(a) < 3 {
-		fmt.Fprintln(stderr, "usage: zenflow goal <goal> [<extra-context>] [--model MODEL] [--max-concurrency N] [--max-depth N] [--timeout DURATION] [--workdir DIR] [--json] [--quiet] [--summary-only] [--stream] [--trace] [--thinking LEVEL] [--mcp-config PATH] [--no-mcp] [--verbose] [--yolo] [--sandbox] [--allow LIST] [--deny LIST] [--strict]")
+		fmt.Fprintln(stderr, "usage: zenflow goal <goal> [<extra-context>] [--model MODEL] [--max-concurrency N] [--max-depth N] [--timeout DURATION] [--workdir DIR] [--json] [--quiet] [--summary-only] [--stream] [--trace] [--thinking LEVEL] [--mcp-config PATH] [--no-mcp] [--env-file PATH] [--no-dotenv] [--verbose] [--yolo] [--sandbox] [--allow LIST] [--deny LIST] [--strict]")
 		exit(3)
 		return
 	}
@@ -64,6 +64,9 @@ func cmdGoal() {
 		exit(3)
 		return
 	}
+	// Auto-load .env so ${VAR} in the decomposed workflow and MCP config
+	// resolve from the operator's environment (issue #16).
+	loadDotEnv(flags)
 	// Install OTel exporter BEFORE building orchestrator opts so that
 	// zenotel.WithTracing inside buildOrchestratorOpts picks up the
 	// registered global provider. Deferred shutdown flushes buffered spans.

--- a/cmd/zenflow/dotenv.go
+++ b/cmd/zenflow/dotenv.go
@@ -134,13 +134,13 @@ func isEnvKey(k string) bool {
 	for i := 0; i < len(k); i++ {
 		c := k[i]
 		alpha := c == '_' || (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z')
-		if i == 0 {
-			if !alpha {
-				return false
-			}
-			continue
-		}
-		if !alpha && !(c >= '0' && c <= '9') {
+		digit := c >= '0' && c <= '9'
+		switch {
+		case i == 0 && alpha:
+			// leading char must be a letter or underscore
+		case i > 0 && (alpha || digit):
+			// subsequent chars may also be digits
+		default:
 			return false
 		}
 	}

--- a/cmd/zenflow/dotenv.go
+++ b/cmd/zenflow/dotenv.go
@@ -1,0 +1,148 @@
+package main
+
+// dotenv.go - optional .env auto-loading for the flow / goal / agent
+// subcommands. Before a run, zenflow reads a shell-style .env file
+// (default ./.env in the working directory) and sets every variable it
+// declares that is NOT already present in the process environment - an
+// exported value always wins over the file. The populated environment then
+// feeds ${VAR} interpolation in workflow YAML (issue #16) and ${VAR}
+// expansion in MCP server config.
+//
+// Like .zenflow/settings.json, a .env is a trust boundary: it can inject
+// secrets and paths into the run, so it is loaded only from the working
+// directory. Disable it with --no-dotenv or point at an explicit file with
+// --env-file.
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// defaultDotEnvPath is the conventional env file, relative to the working
+// directory (after --workdir has chdir'd).
+const defaultDotEnvPath = ".env"
+
+// osSetenv is a test seam for the process-environment mutation.
+var osSetenv = os.Setenv
+
+// dotEnvEntry is a single parsed KEY=VALUE pair.
+type dotEnvEntry struct{ key, val string }
+
+// loadDotEnv reads the .env file selected by flags and applies its entries
+// to the process environment without overriding already-set variables. A
+// missing default file is silently ignored; a missing explicit --env-file
+// is reported. Parse/read errors are reported and skipped rather than
+// aborting the run, mirroring the best-effort posture of MCP loading.
+func loadDotEnv(flags cmdFlags) {
+	if flags.noDotEnv {
+		return
+	}
+	path := flags.envFile
+	explicit := path != ""
+	if path == "" {
+		path = defaultDotEnvPath
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			if explicit {
+				fmt.Fprintf(stderr, "zenflow: env file not found: %s\n", path)
+			}
+			return
+		}
+		fmt.Fprintf(stderr, "zenflow: env file: %v\n", err)
+		return
+	}
+	entries, perr := parseDotEnv(string(data))
+	if perr != nil {
+		fmt.Fprintf(stderr, "zenflow: env file %s: %v\n", path, perr)
+		return
+	}
+	set := 0
+	for _, e := range entries {
+		if _, ok := os.LookupEnv(e.key); ok {
+			continue // exported value wins over .env
+		}
+		if err := osSetenv(e.key, e.val); err != nil {
+			fmt.Fprintf(stderr, "zenflow: env file %s: set %s: %v\n", path, e.key, err)
+			continue
+		}
+		set++
+	}
+	if flags.verbose && set > 0 {
+		fmt.Fprintf(stderr, "zenflow: loaded %d var(s) from %s\n", set, path)
+	}
+}
+
+// parseDotEnv parses KEY=VALUE lines. It supports blank lines, `#`
+// comments, an optional leading `export `, single/double-quoted values
+// (surrounding quotes stripped, contents kept verbatim) and unquoted
+// values (surrounding whitespace trimmed, a trailing ` #` inline comment
+// dropped). It rejects lines without `=` and invalid variable names so a
+// typo fails fast rather than silently doing nothing.
+func parseDotEnv(s string) ([]dotEnvEntry, error) {
+	var out []dotEnvEntry
+	sc := bufio.NewScanner(strings.NewReader(s))
+	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	lineNo := 0
+	for sc.Scan() {
+		lineNo++
+		line := strings.TrimSpace(sc.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		if rest, ok := strings.CutPrefix(line, "export "); ok {
+			line = strings.TrimSpace(rest)
+		}
+		k, v, ok := strings.Cut(line, "=")
+		if !ok {
+			return nil, fmt.Errorf("line %d: missing '=' (expected KEY=VALUE)", lineNo)
+		}
+		key := strings.TrimSpace(k)
+		if !isEnvKey(key) {
+			return nil, fmt.Errorf("line %d: invalid variable name %q", lineNo, key)
+		}
+		out = append(out, dotEnvEntry{key: key, val: unquoteDotEnvValue(strings.TrimSpace(v))})
+	}
+	if err := sc.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// unquoteDotEnvValue strips a matching pair of surrounding quotes, or for
+// an unquoted value drops a trailing ` #` inline comment.
+func unquoteDotEnvValue(v string) string {
+	if len(v) >= 2 {
+		if c := v[0]; (c == '"' || c == '\'') && v[len(v)-1] == c {
+			return v[1 : len(v)-1]
+		}
+	}
+	if i := strings.Index(v, " #"); i >= 0 {
+		return strings.TrimSpace(v[:i])
+	}
+	return v
+}
+
+// isEnvKey reports whether k is a valid env var name ([A-Za-z_][A-Za-z0-9_]*).
+func isEnvKey(k string) bool {
+	if k == "" {
+		return false
+	}
+	for i := 0; i < len(k); i++ {
+		c := k[i]
+		alpha := c == '_' || (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z')
+		if i == 0 {
+			if !alpha {
+				return false
+			}
+			continue
+		}
+		if !alpha && !(c >= '0' && c <= '9') {
+			return false
+		}
+	}
+	return true
+}

--- a/cmd/zenflow/dotenv_test.go
+++ b/cmd/zenflow/dotenv_test.go
@@ -1,0 +1,219 @@
+package main
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestParseDotEnv(t *testing.T) {
+	in := strings.Join([]string{
+		"# a comment",
+		"",
+		"FOO=bar",
+		"export BAZ=qux",
+		`QUOTED="hello world"`,
+		"SINGLE='it''s'",
+		"INLINE=value # trailing comment",
+		"EMPTY=",
+		"SPACED =  trimmed  ",
+	}, "\n")
+	got, err := parseDotEnv(in)
+	if err != nil {
+		t.Fatalf("parseDotEnv: %v", err)
+	}
+	want := map[string]string{
+		"FOO":    "bar",
+		"BAZ":    "qux",
+		"QUOTED": "hello world",
+		"SINGLE": "it''s", // surrounding single quotes stripped, content verbatim
+		"INLINE": "value",
+		"EMPTY":  "",
+		"SPACED": "trimmed",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got %d entries, want %d: %+v", len(got), len(want), got)
+	}
+	for _, e := range got {
+		w, ok := want[e.key]
+		if !ok {
+			t.Errorf("unexpected key %q", e.key)
+			continue
+		}
+		if e.val != w {
+			t.Errorf("%s = %q, want %q", e.key, e.val, w)
+		}
+	}
+}
+
+func TestParseDotEnv_Errors(t *testing.T) {
+	if _, err := parseDotEnv("NOEQUALS"); err == nil || !strings.Contains(err.Error(), "missing '='") {
+		t.Errorf("missing '=' err = %v", err)
+	}
+	if _, err := parseDotEnv("1BAD=x"); err == nil || !strings.Contains(err.Error(), "invalid variable name") {
+		t.Errorf("invalid name err = %v", err)
+	}
+	// A single line longer than the 1 MiB scanner cap surfaces a scanner
+	// error rather than silently truncating.
+	huge := "K=" + strings.Repeat("v", 2*1024*1024)
+	if _, err := parseDotEnv(huge); err == nil {
+		t.Error("expected scanner error on oversized line")
+	}
+}
+
+func TestUnquoteDotEnvValue(t *testing.T) {
+	cases := map[string]string{
+		`"x"`:       "x",
+		`'y'`:       "y",
+		`bare`:      "bare",
+		`a # c`:     "a",
+		`"unclosed`: `"unclosed`,
+		`'`:         `'`,
+		`mismatch"`: `mismatch"`,
+		`v#nospace`: "v#nospace",
+		`""`:        "",
+	}
+	for in, want := range cases {
+		if got := unquoteDotEnvValue(in); got != want {
+			t.Errorf("unquoteDotEnvValue(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestIsEnvKey(t *testing.T) {
+	valid := []string{"A", "_x", "FOO_BAR", "x9"}
+	invalid := []string{"", "9x", "a-b", "a b", "a.b"}
+	for _, v := range valid {
+		if !isEnvKey(v) {
+			t.Errorf("isEnvKey(%q) = false, want true", v)
+		}
+	}
+	for _, v := range invalid {
+		if isEnvKey(v) {
+			t.Errorf("isEnvKey(%q) = true, want false", v)
+		}
+	}
+}
+
+// recordSetenv swaps osSetenv for a recorder that does not touch the real
+// environment. failKey, if non-empty, makes that key return an error.
+func recordSetenv(t *testing.T, failKey string) map[string]string {
+	t.Helper()
+	rec := map[string]string{}
+	prev := osSetenv
+	osSetenv = func(k, v string) error {
+		if k == failKey {
+			return errors.New("boom")
+		}
+		rec[k] = v
+		return nil
+	}
+	t.Cleanup(func() { osSetenv = prev })
+	return rec
+}
+
+func TestLoadDotEnv_SetsMissingRespectsExisting(t *testing.T) {
+	dir := t.TempDir()
+	envPath := filepath.Join(dir, ".env")
+	if err := os.WriteFile(envPath, []byte("ZF_NEW=fromfile\nZF_EXISTING=fromfile\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("ZF_EXISTING", "fromenv") // exported value must win
+	rec := recordSetenv(t, "")
+
+	loadDotEnv(cmdFlags{envFile: envPath, verbose: true})
+
+	if rec["ZF_NEW"] != "fromfile" {
+		t.Errorf("ZF_NEW not set: %v", rec)
+	}
+	if _, ok := rec["ZF_EXISTING"]; ok {
+		t.Errorf("ZF_EXISTING should not be overridden")
+	}
+}
+
+func TestLoadDotEnv_Disabled(t *testing.T) {
+	rec := recordSetenv(t, "")
+	loadDotEnv(cmdFlags{noDotEnv: true, envFile: "whatever"})
+	if len(rec) != 0 {
+		t.Errorf("expected no sets when disabled, got %v", rec)
+	}
+}
+
+func TestLoadDotEnv_DefaultMissingIsSilent(t *testing.T) {
+	t.Chdir(t.TempDir()) // no .env here
+	buf := captureStderr(t)
+	rec := recordSetenv(t, "")
+	loadDotEnv(cmdFlags{})
+	if len(rec) != 0 || buf.Len() != 0 {
+		t.Errorf("default missing should be silent no-op; sets=%v stderr=%q", rec, buf.String())
+	}
+}
+
+func TestLoadDotEnv_ExplicitMissingReports(t *testing.T) {
+	buf := captureStderr(t)
+	recordSetenv(t, "")
+	loadDotEnv(cmdFlags{envFile: filepath.Join(t.TempDir(), "nope.env")})
+	if !strings.Contains(buf.String(), "env file not found") {
+		t.Errorf("stderr = %q, want not-found report", buf.String())
+	}
+}
+
+func TestLoadDotEnv_ReadErrorReports(t *testing.T) {
+	// Point at a directory: ReadFile fails with a non-NotExist error.
+	buf := captureStderr(t)
+	recordSetenv(t, "")
+	loadDotEnv(cmdFlags{envFile: t.TempDir()})
+	if !strings.Contains(buf.String(), "env file:") {
+		t.Errorf("stderr = %q, want read-error report", buf.String())
+	}
+}
+
+func TestLoadDotEnv_ParseErrorReports(t *testing.T) {
+	dir := t.TempDir()
+	envPath := filepath.Join(dir, "bad.env")
+	if err := os.WriteFile(envPath, []byte("NOEQUALS\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	buf := captureStderr(t)
+	recordSetenv(t, "")
+	loadDotEnv(cmdFlags{envFile: envPath})
+	if !strings.Contains(buf.String(), "missing '='") {
+		t.Errorf("stderr = %q, want parse-error report", buf.String())
+	}
+}
+
+func TestLoadDotEnv_SetenvErrorReports(t *testing.T) {
+	dir := t.TempDir()
+	envPath := filepath.Join(dir, ".env")
+	if err := os.WriteFile(envPath, []byte("ZF_FAILS=x\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	buf := captureStderr(t)
+	recordSetenv(t, "ZF_FAILS")
+	loadDotEnv(cmdFlags{envFile: envPath})
+	if !strings.Contains(buf.String(), "set ZF_FAILS") {
+		t.Errorf("stderr = %q, want setenv-error report", buf.String())
+	}
+}
+
+func TestParseFlags_DotEnvFlags(t *testing.T) {
+	f, err := parseFlags([]string{"--env-file", "custom.env", "--no-dotenv"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if f.envFile != "custom.env" {
+		t.Errorf("envFile = %q, want custom.env", f.envFile)
+	}
+	if !f.noDotEnv {
+		t.Errorf("noDotEnv = false, want true")
+	}
+}
+
+func TestParseFlags_EnvFileRequiresValue(t *testing.T) {
+	_, err := parseFlags([]string{"--env-file"})
+	if err == nil || !strings.Contains(err.Error(), "--env-file requires a path") {
+		t.Fatalf("err = %v, want --env-file requires a path", err)
+	}
+}

--- a/cmd/zenflow/flags.go
+++ b/cmd/zenflow/flags.go
@@ -34,6 +34,8 @@ type cmdFlags struct {
 	thinking       string // reasoning/thinking level: off|low|medium|high (default off)
 	mcpConfig      string // path to MCP settings.json (default .zenflow/settings.json)
 	noMCP          bool   // disable MCP server loading entirely
+	envFile        string // path to .env file (default ./.env if present)
+	noDotEnv       bool   // disable .env auto-loading entirely
 }
 
 // parseFlags parses common CLI flags from args (starting after the positional argument).
@@ -163,6 +165,14 @@ func parseFlags(args []string) (cmdFlags, error) {
 			f.mcpConfig = args[i]
 		case "--no-mcp":
 			f.noMCP = true
+		case "--env-file":
+			i++
+			if i >= len(args) {
+				return f, fmt.Errorf("--env-file requires a path")
+			}
+			f.envFile = args[i]
+		case "--no-dotenv":
+			f.noDotEnv = true
 		case "--thinking":
 			i++
 			if i >= len(args) {

--- a/cmd/zenflow/main.go
+++ b/cmd/zenflow/main.go
@@ -263,6 +263,8 @@ func usage(w io.Writer) {
 	fmt.Fprintln(w, "  --thinking LEVEL    Extended reasoning: off|low|medium|high (default off)")
 	fmt.Fprintln(w, "  --mcp-config PATH   MCP servers settings.json (default .zenflow/settings.json if present)")
 	fmt.Fprintln(w, "  --no-mcp            Disable MCP server loading")
+	fmt.Fprintln(w, "  --env-file PATH     Env file for ${VAR} interpolation (default ./.env if present)")
+	fmt.Fprintln(w, "  --no-dotenv         Disable .env auto-loading")
 	fmt.Fprintln(w, "  --help, -h          Print this help text")
 	fmt.Fprintln(w, "  --version, -v       Print zenflow version")
 	fmt.Fprintln(w, "")

--- a/docs/cli/flags.md
+++ b/docs/cli/flags.md
@@ -24,6 +24,17 @@ The `Applies to` column lists the verbs that recognize the flag. Flags not liste
 | `--mcp-config PATH` | path | `.zenflow/settings.json` | flow, goal, agent | Read [MCP](/integrations/mcp) servers from a Claude-compatible `settings.json` at `PATH`. When unset, the default path is loaded if present (a missing default is a silent no-op; a missing explicit `PATH` is reported). Discovered tools are namespaced `<server>__<tool>` and grantable by bare server name in an agent's `tools:`. The file launches local commands - it is a [trust boundary](/integrations/mcp#security). |
 | `--no-mcp` | bool | off | flow, goal, agent | Skip MCP server loading entirely, even if a config file is present. |
 
+## Environment variables
+
+Free-text workflow fields (`description`, `agents.*.prompt`, `steps.*.instructions`) support `${VAR}` / `$VAR` interpolation resolved from the process environment at load time (see [Spec §9.1](https://github.com/zendev-sh/zenflow/blob/main/spec/v1/spec.md)). An unset variable expands to `""`; write a literal dollar as `$$`. `toolInput` is excluded ( `$` there is reserved for CEL).
+
+Before a run, the CLI auto-loads a `.env` file from the working directory and applies any variable it declares that is not already exported (an exported value always wins).
+
+| Flag | Type | Default | Applies to | Description |
+| --- | --- | --- | --- | --- |
+| `--env-file PATH` | path | `./.env` | flow, goal, agent | Load env vars from a shell-style `.env` at `PATH` (supports `export `, `#` comments, and quoted values). A missing default is a silent no-op; a missing explicit `PATH` is reported. Like the MCP config, a `.env` is a trust boundary. |
+| `--no-dotenv` | bool | off | flow, goal, agent | Skip `.env` auto-loading entirely. |
+
 ## Lifecycle and execution
 
 | Flag | Type | Default | Applies to | Description |

--- a/docs/concepts/composition.md
+++ b/docs/concepts/composition.md
@@ -144,6 +144,18 @@ The sub-workflow file is parsed as a full zenflow document. It can have its own 
 - **Recursive includes.** A sub-workflow can itself contain includes. Includes are hard-capped at depth 5 (`MaxIncludeDepth`). Going deeper returns a `ValidationError`. Sub-workflow expansion (which counts nested loops + includes after expansion) has a separate cap of 20 (`MaxNestingDepth`).
 - **Path resolution.** File paths in `includes` are relative to the **including** workflow file's directory, not the working directory.
 
+## Environment variable interpolation
+
+Alongside `@file` references, the free-text fields `description`, `agents.*.prompt`, and `steps.*.instructions` support `${VAR}` / `$VAR` interpolation resolved from the host environment at load time. This keeps a workflow reusable across environments without templating the YAML by hand:
+
+```yaml
+steps:
+  - id: crawl
+    instructions: "Fetch and summarize ${RSS_FEED_URL}."
+```
+
+Unset variables expand to the empty string; a literal dollar is written `$$` (`$${X}` -> `${X}`). Interpolation also reaches the contents of an `@`-referenced file and the reference path itself (`"@${DIR}/prompt.md"`). `toolInput` is excluded -- a leading `$` there is reserved for CEL expressions. The `zenflow` CLI auto-loads a `.env` file from the working directory (`--no-dotenv` to disable, `--env-file` to redirect); an exported value always wins over the file. See [Spec §9.1](https://github.com/zendev-sh/zenflow/blob/main/spec/v1/spec.md) and [CLI / Flags](/cli/flags#environment-variables).
+
 ## Reference resolution
 
 When a step has `include: foo`:

--- a/docs/yaml/step.md
+++ b/docs/yaml/step.md
@@ -86,6 +86,8 @@ steps:
     instructions: "@instructions/plan-feature.md"
 ```
 
+`instructions` also supports `${VAR}` / `$VAR` environment-variable interpolation, resolved at load time from the host environment (an unset variable becomes `""`, a literal dollar is `$$`). This applies to inline text and to the contents of an `@`-referenced file. `toolInput` is **not** interpolated -- a leading `$` there is reserved for CEL. See [Spec §9.1](https://github.com/zendev-sh/zenflow/blob/main/spec/v1/spec.md) and [CLI / Flags](/cli/flags#environment-variables) for `.env` auto-loading.
+
 When a step has dependencies, the engine prepends the dependency outputs to the agent context automatically; `instructions` does not need template syntax to reference upstream content. See [Concepts / DAG Scheduling](/concepts/dag-scheduling) for the data-passing rules.
 
 Maximum length: 2000 chars (`MaxDescriptionChars`).

--- a/internal/exec/env_expand.go
+++ b/internal/exec/env_expand.go
@@ -1,0 +1,124 @@
+package exec
+
+// env_expand.go - ${VAR} / $VAR environment-variable interpolation for
+// workflow free-text fields (issue #16). The operator's process
+// environment (populated via `export` or an auto-loaded .env at the CLI
+// layer) is the trust boundary: references resolve from os.Getenv and an
+// unset variable expands to the empty string, matching shell `export`
+// semantics so a partially-configured flow degrades the same way a shell
+// script would rather than erroring out.
+//
+// Scope is deliberately narrow. Only natural-language fields are expanded:
+// the workflow description, agent prompts, and step instructions
+// (including steps nested in loops). Structural identifiers (names, IDs)
+// and machine-interpreted fields are left alone - in particular toolInput
+// already reserves a leading `$` for CEL expressions (spec §7.4), so
+// expanding it here would collide with that contract.
+
+import (
+	"os"
+	"strings"
+)
+
+// expandEnvVars substitutes ${NAME} and $NAME with the value of the NAME
+// environment variable, or the empty string when NAME is unset. NAME must
+// match [A-Za-z_][A-Za-z0-9_]*. A literal dollar is written `$$` (`$${X}`
+// yields the literal text `${X}`), mirroring the `$$` -> `$` escape the
+// spec already uses for toolInput CEL values. Any other `$` - `$5`, `$ `,
+// a trailing `$`, or `${` without a valid name/close - is left untouched,
+// so prices and shell snippets embedded in free text survive verbatim.
+func expandEnvVars(s string) string {
+	start := strings.IndexByte(s, '$')
+	if start < 0 {
+		return s // fast path: nothing to expand
+	}
+	var b strings.Builder
+	b.Grow(len(s))
+	b.WriteString(s[:start])
+	for i := start; i < len(s); {
+		if s[i] != '$' {
+			b.WriteByte(s[i])
+			i++
+			continue
+		}
+		// s[i] == '$'
+		if i+1 >= len(s) {
+			b.WriteByte('$') // trailing '$' is literal
+			break
+		}
+		switch next := s[i+1]; {
+		case next == '$':
+			b.WriteByte('$') // `$$` escape -> literal `$`
+			i += 2
+		case next == '{':
+			closeIdx := strings.IndexByte(s[i+2:], '}')
+			name := ""
+			if closeIdx >= 0 {
+				name = s[i+2 : i+2+closeIdx]
+			}
+			if closeIdx >= 0 && isEnvName(name) {
+				b.WriteString(os.Getenv(name))
+				i = i + 2 + closeIdx + 1
+			} else {
+				// Unterminated or non-name `${...}`: emit `$` and rescan.
+				b.WriteByte('$')
+				i++
+			}
+		case isNameStart(next):
+			j := i + 1
+			for j < len(s) && isNameChar(s[j]) {
+				j++
+			}
+			b.WriteString(os.Getenv(s[i+1 : j]))
+			i = j
+		default:
+			b.WriteByte('$') // `$5`, `$ `, etc. stay literal
+			i++
+		}
+	}
+	return b.String()
+}
+
+// isEnvName reports whether name is a valid environment-variable
+// identifier ([A-Za-z_][A-Za-z0-9_]*).
+func isEnvName(name string) bool {
+	if name == "" || !isNameStart(name[0]) {
+		return false
+	}
+	for i := 1; i < len(name); i++ {
+		if !isNameChar(name[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func isNameStart(c byte) bool {
+	return c == '_' || (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z')
+}
+
+func isNameChar(c byte) bool {
+	return isNameStart(c) || (c >= '0' && c <= '9')
+}
+
+// expandWorkflowEnv interpolates environment variables across every
+// free-text field of wf in place: the description, each agent prompt, and
+// every step's instructions (recursing into loop bodies).
+func expandWorkflowEnv(wf *Workflow) {
+	wf.Description = expandEnvVars(wf.Description)
+	for name, agent := range wf.Agents {
+		agent.Prompt = expandEnvVars(agent.Prompt)
+		wf.Agents[name] = agent
+	}
+	expandStepsEnv(wf.Steps)
+}
+
+// expandStepsEnv expands instructions for steps and any nested loop steps.
+func expandStepsEnv(steps []Step) {
+	for i := range steps {
+		steps[i].Instructions = expandEnvVars(steps[i].Instructions)
+		if steps[i].Loop != nil {
+			expandStepsEnv(steps[i].Loop.Steps)
+		}
+	}
+}

--- a/internal/exec/env_expand_test.go
+++ b/internal/exec/env_expand_test.go
@@ -1,0 +1,169 @@
+package exec
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestExpandEnvVars covers the substitution scanner: ${VAR}/$VAR forms,
+// unset -> empty, the $$ escape, and the literals it must leave untouched.
+func TestExpandEnvVars(t *testing.T) {
+	t.Setenv("ZF_HOST", "example.com")
+	t.Setenv("ZF_EMPTY", "")
+
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"no dollar fast path", "plain text", "plain text"},
+		{"braced", "https://${ZF_HOST}/feed", "https://example.com/feed"},
+		{"bare", "host is $ZF_HOST done", "host is example.com done"},
+		{"bare at end", "host=$ZF_HOST", "host=example.com"},
+		{"set but empty", "[${ZF_EMPTY}]", "[]"},
+		{"unset braced -> empty", "x${ZF_MISSING}y", "xy"},
+		{"unset bare -> empty", "x $ZF_MISSING y", "x  y"},
+		{"escape braced", "cost $${ZF_HOST}", "cost ${ZF_HOST}"},
+		{"escape bare", "price $$5 each", "price $5 each"},
+		{"dollar digit literal", "save $5 now", "save $5 now"},
+		{"dollar space literal", "a $ b", "a $ b"},
+		{"trailing dollar literal", "ends with $", "ends with $"},
+		{"unterminated brace literal", "a ${ZF_HOST", "a ${ZF_HOST"},
+		{"non-name brace literal", "a ${1BAD} b", "a ${1BAD} b"},
+		{"invalid char mid-name literal", "a ${A-B} c", "a ${A-B} c"},
+		{"empty brace literal", "a ${} b", "a ${} b"},
+		{"multiple", "$ZF_HOST/${ZF_HOST}", "example.com/example.com"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := expandEnvVars(tc.in); got != tc.want {
+				t.Errorf("expandEnvVars(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestExpandWorkflowEnv verifies interpolation reaches description, agent
+// prompts, top-level instructions and loop-nested instructions, while
+// leaving IDs and toolInput ($-reserved for CEL) untouched.
+func TestExpandWorkflowEnv(t *testing.T) {
+	t.Setenv("ZF_URL", "https://example.com")
+	t.Setenv("ZF_TOPIC", "otters")
+
+	mi := 3
+	wf := &Workflow{
+		Name:        "wf",
+		Description: "scrape ${ZF_URL}",
+		Agents: map[string]AgentConfig{
+			"writer": {Description: "d", Prompt: "write about ${ZF_TOPIC}"},
+		},
+		Steps: []Step{
+			{ID: "a", Instructions: "fetch ${ZF_URL}"},
+			{ID: "b", Loop: &Loop{
+				MaxIterations: &mi,
+				Steps:         []Step{{ID: "inner", Instructions: "loop ${ZF_TOPIC}"}},
+			}},
+			// toolInput must NOT be expanded ($ is CEL there).
+			{ID: "c", Tool: "read", ToolInput: map[string]any{"path": "${ZF_URL}"}},
+		},
+	}
+	expandWorkflowEnv(wf)
+
+	if wf.Description != "scrape https://example.com" {
+		t.Errorf("description = %q", wf.Description)
+	}
+	if got := wf.Agents["writer"].Prompt; got != "write about otters" {
+		t.Errorf("agent prompt = %q", got)
+	}
+	if wf.Steps[0].Instructions != "fetch https://example.com" {
+		t.Errorf("step a = %q", wf.Steps[0].Instructions)
+	}
+	if got := wf.Steps[1].Loop.Steps[0].Instructions; got != "loop otters" {
+		t.Errorf("inner step = %q", got)
+	}
+	if got := wf.Steps[2].ToolInput["path"]; got != "${ZF_URL}" {
+		t.Errorf("toolInput must be untouched, got %v", got)
+	}
+}
+
+// TestParseWorkflow_EnvInterpolation is the end-to-end parse path: a ${VAR}
+// in YAML instructions is resolved by ParseWorkflow.
+func TestParseWorkflow_EnvInterpolation(t *testing.T) {
+	t.Setenv("ZF_FEED", "https://rss.example.com/feed.xml")
+	yaml := `
+name: feeds
+steps:
+  - id: scrape
+    instructions: "Scrape ${ZF_FEED} and summarize."
+`
+	wf, err := ParseWorkflow([]byte(yaml))
+	if err != nil {
+		t.Fatalf("ParseWorkflow: %v", err)
+	}
+	if !strings.Contains(wf.Steps[0].Instructions, "https://rss.example.com/feed.xml") {
+		t.Errorf("instructions not interpolated: %q", wf.Steps[0].Instructions)
+	}
+}
+
+// TestLoadWorkflow_EnvInRefPathAndContent covers the @-ref path: a ${VAR}
+// in the ref path resolves the file, and ${VAR} inside the referenced file
+// is interpolated too.
+func TestLoadWorkflow_EnvInRefPathAndContent(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("ZF_REF", "prompt.md")
+	t.Setenv("ZF_NAME", "Ada")
+
+	if err := os.WriteFile(filepath.Join(dir, "prompt.md"), []byte("Hello ${ZF_NAME}, summarize."), 0o600); err != nil {
+		t.Fatalf("write ref: %v", err)
+	}
+	// The instructions reference the file via an env-built (relative) path.
+	wfYAML := "name: x\nversion: 1\nsteps:\n  - id: s\n    instructions: \"@${ZF_REF}\"\n"
+	wfPath := filepath.Join(dir, "wf.yaml")
+	if err := os.WriteFile(wfPath, []byte(wfYAML), 0o600); err != nil {
+		t.Fatalf("write wf: %v", err)
+	}
+	wf, err := LoadWorkflow(wfPath)
+	if err != nil {
+		t.Fatalf("LoadWorkflow: %v", err)
+	}
+	if wf.Steps[0].Instructions != "Hello Ada, summarize." {
+		t.Errorf("ref content not interpolated: %q", wf.Steps[0].Instructions)
+	}
+}
+
+// TestLoadWorkflow_EnvInAgentPromptRef covers @-ref expansion on an agent
+// prompt loaded from a file.
+func TestLoadWorkflow_EnvInAgentPromptRef(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("ZF_NAME", "Bob")
+	if err := os.WriteFile(filepath.Join(dir, "sys.md"), []byte("You are ${ZF_NAME}."), 0o600); err != nil {
+		t.Fatalf("write ref: %v", err)
+	}
+	wfYAML := "name: x\nversion: 1\nagents:\n  w:\n    description: d\n    prompt: \"@sys.md\"\nsteps:\n  - id: s\n    agent: w\n    instructions: go\n"
+	wfPath := filepath.Join(dir, "wf.yaml")
+	if err := os.WriteFile(wfPath, []byte(wfYAML), 0o600); err != nil {
+		t.Fatalf("write wf: %v", err)
+	}
+	wf, err := LoadWorkflow(wfPath)
+	if err != nil {
+		t.Fatalf("LoadWorkflow: %v", err)
+	}
+	if got := wf.Agents["w"].Prompt; got != "You are Bob." {
+		t.Errorf("agent prompt ref not interpolated: %q", got)
+	}
+}
+
+// TestParseWorkflowJSON_EnvInterpolation covers the JSON parse path.
+func TestParseWorkflowJSON_EnvInterpolation(t *testing.T) {
+	t.Setenv("ZF_FEED", "https://rss.example.com/feed.xml")
+	js := `{"name":"feeds","steps":[{"id":"scrape","instructions":"Scrape ${ZF_FEED}."}]}`
+	wf, err := ParseWorkflowJSON([]byte(js))
+	if err != nil {
+		t.Fatalf("ParseWorkflowJSON: %v", err)
+	}
+	if !strings.Contains(wf.Steps[0].Instructions, "https://rss.example.com/feed.xml") {
+		t.Errorf("instructions not interpolated: %q", wf.Steps[0].Instructions)
+	}
+}

--- a/internal/exec/parse.go
+++ b/internal/exec/parse.go
@@ -86,6 +86,11 @@ func ParseWorkflowJSON(data []byte) (*Workflow, error) {
 		return nil, &ValidationError{Message: err.Error()}
 	}
 
+	// Interpolate ${VAR} references before sanitising/validating so the
+	// substituted text is Unicode-checked and counted against size limits
+	// just like inline content (issue #16).
+	expandWorkflowEnv(&wf)
+
 	if err := SanitizeWorkflowUnicode(&wf); err != nil {
 		return nil, err
 	}
@@ -113,6 +118,11 @@ func ParseWorkflow(data []byte) (*Workflow, error) {
 	if err := dec.Decode(&wf); err != nil {
 		return nil, &ValidationError{Message: err.Error()}
 	}
+
+	// Interpolate ${VAR} references before sanitising/validating so the
+	// substituted text is Unicode-checked and counted against size limits
+	// just like inline content (issue #16).
+	expandWorkflowEnv(&wf)
 
 	if err := SanitizeWorkflowUnicode(&wf); err != nil {
 		return nil, err
@@ -507,13 +517,18 @@ func ValidateWorkflow(wf *Workflow) ([]string, error) {
 // non-empty content begins with `@` triggers another resolution) and
 // rejected at depth > MaxNestingDepth.
 func resolveRefs(wf *Workflow, baseDir string) error {
+	// @-ref'd file contents are interpolated too (expandEnvVars), so a
+	// referenced instructions/prompt file may use ${VAR} just like inline
+	// text (issue #16). Inline fields were already expanded in
+	// ParseWorkflow; the ref path itself was expanded there as well, so
+	// `@${DIR}/prompt.md` resolves against the substituted path.
 	for name, agent := range wf.Agents {
 		if strings.HasPrefix(agent.Prompt, "@") {
 			content, err := resolveChainedRef(baseDir, agent.Prompt[1:], 1, map[string]bool{})
 			if err != nil {
 				return &ValidationError{Message: "agent " + name + " prompt: " + err.Error()}
 			}
-			agent.Prompt = content
+			agent.Prompt = expandEnvVars(content)
 			wf.Agents[name] = agent
 		}
 	}
@@ -524,7 +539,7 @@ func resolveRefs(wf *Workflow, baseDir string) error {
 			if err != nil {
 				return &ValidationError{Message: "step " + wf.Steps[i].ID + " instructions: " + err.Error()}
 			}
-			wf.Steps[i].Instructions = content
+			wf.Steps[i].Instructions = expandEnvVars(content)
 		}
 	}
 

--- a/internal/exec/spec/v1/examples/env-interpolation.yaml
+++ b/internal/exec/spec/v1/examples/env-interpolation.yaml
@@ -1,0 +1,20 @@
+# Environment Variable Interpolation -- ${VAR} references in free-text
+# fields (description, agent prompts, step instructions) resolve from the
+# host environment at load time. Unset variables expand to "". Write a
+# literal dollar as $$. See spec.md §9.1.
+#
+# Run with: RSS_FEED_URL=https://example.com/feed.xml zenflow flow env-interpolation.yaml
+# The zenflow CLI also auto-loads a .env file from the working directory.
+
+name: env-interpolation
+description: "Summarize the feed at ${RSS_FEED_URL}."
+
+agents:
+  summarizer:
+    description: "Reads a feed and writes a short digest."
+    prompt: "You summarize RSS feeds. The configured source is ${RSS_FEED_URL}."
+
+steps:
+  - id: summarize
+    agent: summarizer
+    instructions: "Fetch ${RSS_FEED_URL}, then write a 3-bullet summary of its latest items."

--- a/spec/v1/examples/env-interpolation.yaml
+++ b/spec/v1/examples/env-interpolation.yaml
@@ -1,0 +1,20 @@
+# Environment Variable Interpolation -- ${VAR} references in free-text
+# fields (description, agent prompts, step instructions) resolve from the
+# host environment at load time. Unset variables expand to "". Write a
+# literal dollar as $$. See spec.md §9.1.
+#
+# Run with: RSS_FEED_URL=https://example.com/feed.xml zenflow flow env-interpolation.yaml
+# The zenflow CLI also auto-loads a .env file from the working directory.
+
+name: env-interpolation
+description: "Summarize the feed at ${RSS_FEED_URL}."
+
+agents:
+  summarizer:
+    description: "Reads a feed and writes a short digest."
+    prompt: "You summarize RSS feeds. The configured source is ${RSS_FEED_URL}."
+
+steps:
+  - id: summarize
+    agent: summarizer
+    instructions: "Fetch ${RSS_FEED_URL}, then write a 3-bullet summary of its latest items."

--- a/spec/v1/spec.md
+++ b/spec/v1/spec.md
@@ -634,6 +634,31 @@ steps:
       - "docs/api-spec.yaml"
 ```
 
+### 9.1 Environment Variable Interpolation
+
+The free-text fields `description`, `agents.*.prompt`, and `steps.*.instructions` (including instructions of steps nested inside a loop) support `${VAR}` / `$VAR` environment-variable interpolation. References resolve from the host process environment at load time.
+
+| Form | Interpretation |
+|------|----------------|
+| `${RSS_FEED_URL}` | Replaced with the value of `RSS_FEED_URL`. |
+| `$RSS_FEED_URL` | Same; `VAR` matches `[A-Za-z_][A-Za-z0-9_]*`. |
+| `${MISSING}` | An unset variable expands to the empty string. |
+| `$$` | Literal `$`. `$${VAR}` produces the literal text `${VAR}`. |
+| `$5`, `$ `, trailing `$` | Left untouched (not a valid reference). |
+
+Interpolation also applies to the contents of an `@`-referenced file, and to the `@` reference path itself (`"@${DIR}/prompt.md"`).
+
+`toolInput` is **not** interpolated: a leading `$` there is reserved for CEL expressions (§4.1). Use a `description`/`instructions` field, or a CEL expression, to inject dynamic values into a tool step.
+
+Interpolation is a runtime behavior; JSON Schema does not enforce it. Like the `@` convention, parsers perform it during loading. Variables resolve from the environment populated by the host -- the `zenflow` CLI additionally auto-loads a `.env` file from the working directory (disable with `--no-dotenv`, redirect with `--env-file`).
+
+```yaml
+name: crawl-feed
+steps:
+  - id: scrape
+    instructions: "Fetch and summarize the feed at ${RSS_FEED_URL}."
+```
+
 ---
 
 ## 10. Duration Format


### PR DESCRIPTION
## What

Closes #16. Adds `${VAR}` / `$VAR` environment-variable interpolation to workflow free-text fields, plus `.env` auto-loading in the CLI.

```yaml
steps:
  - id: scrape
    instructions: "Fetch and summarize the feed at ${RSS_FEED_URL}."
```

## Behavior

- **Scope**: `description`, `agents.*.prompt`, `steps.*.instructions` (incl. loop-nested steps). Also expands `@`-referenced file contents and the `@` ref path itself (`"@${DIR}/prompt.md"`).
- **Semantics**: unset → `""` (per shell/`export` convention); literal dollar via `$$` (`$${X}` → `${X}`); `$5`, `$ `, trailing `$` left untouched.
- **`toolInput` excluded**: a leading `$` there is already reserved for CEL (spec §4.1), so interpolating it would collide with that contract.
- **`.env`**: `flow`/`goal`/`agent` auto-load `./.env` (shell-style: `export `, `#` comments, quoted values), applying only variables not already exported — an exported value always wins. `--no-dotenv` disables, `--env-file PATH` redirects. Trust boundary, same posture as `.zenflow/settings.json`.

## Lock-step (rule #4)

- Parser: `internal/exec/env_expand.go` (custom scanner) + wired into `ParseWorkflow`/`ParseWorkflowJSON`/`resolveRefs`.
- CLI: `cmd/zenflow/dotenv.go` (loader + parser) + flags + wiring into the three subcommands.
- `spec/v1/spec.md` §9.1; example `env-interpolation.yaml` (both example trees); docs `yaml/step.md`, `cli/flags.md`, `concepts/composition.md`.
- Schema unchanged (runtime content behavior, like `@`-refs — spec notes JSON Schema does not enforce it).

## Verification

- `go test ./...` ✅ — 100% line coverage on all new code (`env_expand.go`, `dotenv.go`).
- `go vet` / `gofmt` / `./scripts/smoke-examples.sh` ✅; new example passes `zenflow validate`.
- **Live e2e** against Gemini: `.env` auto-loaded (`loaded 1 var(s) from .env`), `${ZF_CITY}` expanded to `Reykjavik` before the agent saw it — the exact shape of the issue's `${RSS_FEED_URL}` case.