### PR TITLE
chore: bump goai to v0.9.7

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/google/cel-go v0.27.0
-	github.com/zendev-sh/goai v0.8.5
+	github.com/zendev-sh/goai v0.9.7
 	github.com/zendev-sh/zenflow/observability/otel v0.1.4
 	go.uber.org/goleak v1.3.0
 	golang.org/x/text v0.35.0
@@ -21,7 +21,7 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 // indirect
-	github.com/zendev-sh/goai/observability/otel v0.8.1 // indirect
+	github.com/zendev-sh/goai/observability/otel v0.9.7 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel v1.43.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.43.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -35,10 +35,10 @@ github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0t
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-github.com/zendev-sh/goai v0.8.5 h1:5bXsdRj06S2bDHOR6dahifW4bYCfrv3h/3NQZ2hwgVw=
-github.com/zendev-sh/goai v0.8.5/go.mod h1:F0NPGQu0kzKQOQ0/pWYJ4E3J0EY2TBa+uEvqgOPsSaY=
-github.com/zendev-sh/goai/observability/otel v0.8.1 h1:ybcvlhN4wYTj9Lbp9MuS52CTB7GZT7hTxUnpOS6MDRU=
-github.com/zendev-sh/goai/observability/otel v0.8.1/go.mod h1:caCoMqnjLjVDzP01Sxbo9BLGIjjbKHFglWfxmJdtPm8=
+github.com/zendev-sh/goai v0.9.7 h1:QvsOkKMQ10GAvTIKjFUHHJC6sLA1/AFuIZA+FtcCpQc=
+github.com/zendev-sh/goai v0.9.7/go.mod h1:F0NPGQu0kzKQOQ0/pWYJ4E3J0EY2TBa+uEvqgOPsSaY=
+github.com/zendev-sh/goai/observability/otel v0.9.7 h1:KBSzQ2lZDLcTmZ8rz9vh/MaCFOTkv3bwWMa9QyYnreU=
+github.com/zendev-sh/goai/observability/otel v0.9.7/go.mod h1:caCoMqnjLjVDzP01Sxbo9BLGIjjbKHFglWfxmJdtPm8=
 github.com/zendev-sh/zenflow/observability/otel v0.1.4 h1:B9S1e2nRKtjWJIdCwc08VIj+2oaJpMhzdrFtfETj86M=
 github.com/zendev-sh/zenflow/observability/otel v0.1.4/go.mod h1:BuJQ2b0NMH1KYCvzN8nRjvUDpVd0vRQOGjgl+K59fZc=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=

--- a/observability/otel/go.mod
+++ b/observability/otel/go.mod
@@ -3,8 +3,8 @@ module github.com/zendev-sh/zenflow/observability/otel
 go 1.25.0
 
 require (
-	github.com/zendev-sh/goai v0.7.6
-	github.com/zendev-sh/goai/observability/otel v0.7.6
+	github.com/zendev-sh/goai v0.9.7
+	github.com/zendev-sh/goai/observability/otel v0.9.7
 	github.com/zendev-sh/zenflow v0.1.3
 	go.opentelemetry.io/otel v1.43.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.43.0
@@ -37,4 +37,3 @@ require (
 	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
-

--- a/observability/otel/go.sum
+++ b/observability/otel/go.sum
@@ -33,10 +33,12 @@ github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0t
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-github.com/zendev-sh/goai v0.7.6 h1:O8SomDm28SBQPjpfT4eAM453THBxydP9IfHpX15E8sA=
-github.com/zendev-sh/goai v0.7.6/go.mod h1:64KI8qD64Z/z+2bx4g1yjNDPVORWWN58lNWIYye6S80=
-github.com/zendev-sh/goai/observability/otel v0.7.6 h1:Fr4ih3jSxnsAhhap8SDvhDCnCkhxKk/AyglzSXV+wdU=
-github.com/zendev-sh/goai/observability/otel v0.7.6/go.mod h1:caCoMqnjLjVDzP01Sxbo9BLGIjjbKHFglWfxmJdtPm8=
+github.com/zendev-sh/goai v0.9.7 h1:QvsOkKMQ10GAvTIKjFUHHJC6sLA1/AFuIZA+FtcCpQc=
+github.com/zendev-sh/goai v0.9.7/go.mod h1:F0NPGQu0kzKQOQ0/pWYJ4E3J0EY2TBa+uEvqgOPsSaY=
+github.com/zendev-sh/goai/observability/otel v0.9.7 h1:KBSzQ2lZDLcTmZ8rz9vh/MaCFOTkv3bwWMa9QyYnreU=
+github.com/zendev-sh/goai/observability/otel v0.9.7/go.mod h1:caCoMqnjLjVDzP01Sxbo9BLGIjjbKHFglWfxmJdtPm8=
+github.com/zendev-sh/zenflow v0.1.3 h1:oGbrOiOux5tVtB78w8RctKQvCnxNt4iDMqObGRWKglY=
+github.com/zendev-sh/zenflow v0.1.3/go.mod h1:rm/FzQ04fRRWUOGegm+pnI9WqFgo1ynKFXliXz4tIOE=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
 go.opentelemetry.io/otel v1.43.0 h1:mYIM03dnh5zfN7HautFE4ieIig9amkNANT+xcVxAj9I=


### PR DESCRIPTION
## Summary
- bump github.com/zendev-sh/goai to v0.9.7
- align goai observability/otel to v0.9.7 in both Go modules
- refresh module checksums

## Verification
- go test ./...
- (cd observability/otel && go test ./...)